### PR TITLE
Fix the bug that wrongly use the GCM when GSF is not fully available.

### DIFF
--- a/Parse/src/main/java/com/parse/GcmRegistrar.java
+++ b/Parse/src/main/java/com/parse/GcmRegistrar.java
@@ -15,6 +15,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 import android.os.SystemClock;
 
@@ -44,6 +45,8 @@ import bolts.TaskCompletionSource;
 
   public static final String REGISTER_ACTION = "com.google.android.c2dm.intent.REGISTER";
 
+  private static final String GSF_PACKAGE_NAME = "com.google.android.gsf";
+
   private static final String FILENAME_DEVICE_TOKEN_LAST_MODIFIED = "deviceTokenLastModified";
   private long localDeviceTokenLastModified;
   private final Object localDeviceTokenLastModifiedMutex = new Object();
@@ -67,6 +70,14 @@ import bolts.TaskCompletionSource;
     }
 
     return senderID.substring(3);
+  }
+
+  public static boolean isGcmRegisterServiceAvailable() {
+    Intent intent = new Intent(REGISTER_ACTION);
+    intent.setPackage(GSF_PACKAGE_NAME);
+    List<ResolveInfo> services = Parse.getApplicationContext().getPackageManager().
+            queryIntentServices(intent, 0);
+    return services != null && services.size() > 0;
   }
 
   private final Object lock = new Object();
@@ -337,7 +348,7 @@ import bolts.TaskCompletionSource;
 
     private void send() {
       Intent intent = new Intent(REGISTER_ACTION);
-      intent.setPackage("com.google.android.gsf");
+      intent.setPackage(GSF_PACKAGE_NAME);
       intent.putExtra("sender", senderId);
       intent.putExtra("app", appIntent);
 

--- a/Parse/src/main/java/com/parse/GcmRegistrar.java
+++ b/Parse/src/main/java/com/parse/GcmRegistrar.java
@@ -15,7 +15,6 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 import android.os.SystemClock;
 
@@ -45,8 +44,6 @@ import bolts.TaskCompletionSource;
 
   public static final String REGISTER_ACTION = "com.google.android.c2dm.intent.REGISTER";
 
-  private static final String GSF_PACKAGE_NAME = "com.google.android.gsf";
-
   private static final String FILENAME_DEVICE_TOKEN_LAST_MODIFIED = "deviceTokenLastModified";
   private long localDeviceTokenLastModified;
   private final Object localDeviceTokenLastModifiedMutex = new Object();
@@ -70,14 +67,6 @@ import bolts.TaskCompletionSource;
     }
 
     return senderID.substring(3);
-  }
-
-  public static boolean isGcmRegisterServiceAvailable() {
-    Intent intent = new Intent(REGISTER_ACTION);
-    intent.setPackage(GSF_PACKAGE_NAME);
-    List<ResolveInfo> services = Parse.getApplicationContext().getPackageManager().
-            queryIntentServices(intent, 0);
-    return services != null && services.size() > 0;
   }
 
   private final Object lock = new Object();
@@ -348,7 +337,7 @@ import bolts.TaskCompletionSource;
 
     private void send() {
       Intent intent = new Intent(REGISTER_ACTION);
-      intent.setPackage(GSF_PACKAGE_NAME);
+      intent.setPackage("com.google.android.gsf");
       intent.putExtra("sender", senderId);
       intent.putExtra("app", appIntent);
 

--- a/Parse/src/main/java/com/parse/ManifestInfo.java
+++ b/Parse/src/main/java/com/parse/ManifestInfo.java
@@ -198,6 +198,7 @@ import java.util.List;
     synchronized (lock) {
       if (pushType == null) {
         boolean isGooglePlayServicesAvailable = isGooglePlayServicesAvailable();
+        boolean isGcmRegisterServiceAvailable = isGcmRegisterServiceAvailable();
         boolean isPPNSAvailable = PPNSUtil.isPPNSAvailable();
         boolean hasAnyGcmSpecificDeclaration = hasAnyGcmSpecificDeclaration();
         ManifestCheckResult gcmSupportLevel = gcmSupportLevel();
@@ -211,12 +212,13 @@ import java.util.List;
 
         if (hasPushBroadcastReceiver
             && isGooglePlayServicesAvailable
+            && isGcmRegisterServiceAvailable
             && hasRequiredGcmDeclarations) {
           pushType = PushType.GCM;
         } else if (hasPushBroadcastReceiver
             && isPPNSAvailable
             && hasRequiredPpnsDeclarations
-            && (!hasAnyGcmSpecificDeclaration || !isGooglePlayServicesAvailable)) {
+            && !(isGcmRegisterServiceAvailable && isGooglePlayServicesAvailable && hasAnyGcmSpecificDeclaration)) {
           pushType = PushType.PPNS;
 
           if (isGooglePlayServicesAvailable) {
@@ -464,6 +466,13 @@ import java.util.List;
 
   private static boolean isGooglePlayServicesAvailable() {
     return Build.VERSION.SDK_INT >= 8 && getPackageInfo("com.google.android.gsf") != null;
+  }
+
+  private static boolean isGcmRegisterServiceAvailable() {
+    Intent intent = new Intent(GcmRegistrar.REGISTER_ACTION);
+    intent.setPackage("com.google.android.gsf");
+    List<ResolveInfo> services = getContext().getPackageManager().queryIntentServices(intent, 0);
+    return services != null && services.size() > 0;
   }
 
   private static ManifestCheckResult gcmSupportLevel() {


### PR DESCRIPTION
When I am using Parse push notification, I found I always could not receive any push notification if I am using Huawei phones, and finally I found out that the Huawei phone has google service framework, so Parse would choose GCM as push type, but unfortunately, there is no Play Store in the phone, and somehow when Parse try to register the GCM push, it always got GSF_PACKAGE_NOT_AVAILABLE error, so the push notification won't work at all, but if I install Play Store on the phone, the GCM works.
I don't know whether this is a bug of Huawei's OS, or a bug of Parse, I just fix it. If we can not find the GCM register service, we regard the phone as GCM register unavailable.
With this fix, even there is no Play Store installed in Huawei phones, the push can work in a PPNS mode.
