### PR TITLE
Not allowing setObjectId() in ParseInstallation

### DIFF
--- a/Parse/src/main/java/com/parse/ParseInstallation.java
+++ b/Parse/src/main/java/com/parse/ParseInstallation.java
@@ -95,6 +95,11 @@ public class ParseInstallation extends ParseObject {
   }
 
   @Override
+  public void setObjectId(String newObjectId) {
+    throw new RuntimeException("Installation's objectId cannot be changed");
+  }
+
+  @Override
   /* package */ boolean needsDefaultACL() {
     return false;
   }
@@ -149,7 +154,7 @@ public class ParseInstallation extends ParseObject {
                 && task.getError() instanceof ParseException
                 && ((ParseException) task.getError()).getCode() == ParseException.OBJECT_NOT_FOUND) {
           synchronized (mutex) {
-            setObjectId(null);
+            setState(new State.Builder(getState()).objectId(null).build());
             markAllFieldsDirty();
             return ParseInstallation.super.saveAsync(sessionToken, toAwait);
           }

--- a/Parse/src/main/java/com/parse/ParseInstallation.java
+++ b/Parse/src/main/java/com/parse/ParseInstallation.java
@@ -30,6 +30,7 @@ import bolts.Task;
 public class ParseInstallation extends ParseObject {
   private static final String TAG = "com.parse.ParseInstallation";
 
+  private static final String KEY_OBJECT_ID = "objectId";
   private static final String KEY_INSTALLATION_ID = "installationId";
   private static final String KEY_DEVICE_TYPE = "deviceType";
   private static final String KEY_APP_NAME = "appName";
@@ -45,7 +46,7 @@ public class ParseInstallation extends ParseObject {
   private static final List<String> READ_ONLY_FIELDS = Collections.unmodifiableList(
       Arrays.asList(KEY_DEVICE_TYPE, KEY_INSTALLATION_ID, KEY_DEVICE_TOKEN, KEY_PUSH_TYPE,
           KEY_TIME_ZONE, KEY_LOCALE, KEY_APP_VERSION, KEY_APP_NAME, KEY_PARSE_VERSION,
-          KEY_APP_IDENTIFIER));
+          KEY_APP_IDENTIFIER, KEY_OBJECT_ID));
 
   // TODO(mengyan): Inject into ParseInstallationInstanceController
   /* package */ static ParseCurrentInstallationController getCurrentInstallationController() {

--- a/Parse/src/test/java/com/parse/ParseInstallationTest.java
+++ b/Parse/src/test/java/com/parse/ParseInstallationTest.java
@@ -319,7 +319,19 @@ public class ParseInstallationTest extends ResetPluginsParseTest {
     assertEquals("en", installation.getString(KEY_LOCALE_IDENTIFIER));
   }
 
+  @Test(expected = RuntimeException.class)
+  public void testSetObjectId() throws Exception {
+    ParseCurrentInstallationController controller =
+        mock(ParseCurrentInstallationController.class);
+    ParseInstallation currentInstallation = new ParseInstallation();
+    when(controller.getAsync()).thenReturn(Task.forResult(currentInstallation));
+    ParseCorePlugins.getInstance().registerCurrentInstallationController(controller);
 
+    ParseInstallation installation = ParseInstallation.getCurrentInstallation();
+    assertNotNull(installation);
+    verify(controller, times(1)).getAsync();
+    installation.setObjectId(null);
+  }
 
   // TODO(mengyan): Add testFetchAsync, right now we can not test super methods inside
   // testFetchAsync

--- a/Parse/src/test/java/com/parse/ParseInstallationTest.java
+++ b/Parse/src/test/java/com/parse/ParseInstallationTest.java
@@ -106,6 +106,20 @@ public class ParseInstallationTest extends ResetPluginsParseTest {
     }
   }
 
+  @Test (expected = RuntimeException.class)
+  public void testInstallationObjectIdCannotBeChanged() throws Exception {
+    boolean hasException = false;
+    ParseInstallation installation = new ParseInstallation();
+    try {
+      installation.put("objectId", "abc");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Cannot modify"));
+      hasException = true;
+    }
+    assertTrue(hasException);
+    installation.setObjectId("abc");
+  }
+
   @Test
   public void testSaveAsync() throws Exception {
     String sessionToken = "sessionToken";
@@ -319,19 +333,7 @@ public class ParseInstallationTest extends ResetPluginsParseTest {
     assertEquals("en", installation.getString(KEY_LOCALE_IDENTIFIER));
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testSetObjectId() throws Exception {
-    ParseCurrentInstallationController controller =
-        mock(ParseCurrentInstallationController.class);
-    ParseInstallation currentInstallation = new ParseInstallation();
-    when(controller.getAsync()).thenReturn(Task.forResult(currentInstallation));
-    ParseCorePlugins.getInstance().registerCurrentInstallationController(controller);
 
-    ParseInstallation installation = ParseInstallation.getCurrentInstallation();
-    assertNotNull(installation);
-    verify(controller, times(1)).getAsync();
-    installation.setObjectId(null);
-  }
 
   // TODO(mengyan): Add testFetchAsync, right now we can not test super methods inside
   // testFetchAsync


### PR DESCRIPTION
When I deal with the issue #607, I found another issue about ParseInstallation.
(It's a very special case, generally should not happen.)

```java
ParseInstallation installation = ParseInstallation.getCurrentInstallation();
installation.setObjectId(null);
// put some parameters here
installation.save();
```
I originally expected another installation data will be created in the server.
But the installation data is `updated` successfully and doesn't return any exceptions.
The objectId of cached installation data is also cleared (null).
It seems parser server will refer to 'installationId' when updating the installation data.
In this case, the installation data is not re-created when it is deleted on the server. (will throw [Code 135: MissingRequiredFieldError](http://docs.parseplatform.org/android/guide/#installation-related-errors) exception)
I think it should be restricted the usage of setObjectId() in ParseInstallation.