### PR TITLE
Implementing Parcelable in ParseGeoPoint

### DIFF
--- a/Parse/src/main/java/com/parse/ParseFile.java
+++ b/Parse/src/main/java/com/parse/ParseFile.java
@@ -240,6 +240,7 @@ public class ParseFile implements Parcelable {
    * Creates a new file instance from a {@link Parcel} using the given {@link ParseParcelDecoder}.
    * The decoder is currently unused, but it might be in the future, plus this is the pattern we
    * are using in parcelable classes.
+   *
    * @param source the parcel
    * @param decoder the decoder
    */

--- a/Parse/src/main/java/com/parse/ParseGeoPoint.java
+++ b/Parse/src/main/java/com/parse/ParseGeoPoint.java
@@ -10,6 +10,8 @@ package com.parse;
 
 import android.location.Criteria;
 import android.location.Location;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 import java.util.Locale;
 
@@ -32,7 +34,7 @@ import bolts.Task;
  * </pre>
  */
 
-public class ParseGeoPoint {
+public class ParseGeoPoint implements Parcelable {
   static double EARTH_MEAN_RADIUS_KM = 6371.0;
   static double EARTH_MEAN_RADIUS_MILE = 3958.8;
 
@@ -268,4 +270,27 @@ public class ParseGeoPoint {
   public String toString() {
     return String.format(Locale.US, "ParseGeoPoint[%.6f,%.6f]", latitude, longitude);
   }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    dest.writeDouble(latitude);
+    dest.writeDouble(longitude);
+  }
+
+  public final static Creator<ParseGeoPoint> CREATOR = new Creator<ParseGeoPoint>() {
+    @Override
+    public ParseGeoPoint createFromParcel(Parcel source) {
+      return new ParseGeoPoint(source.readDouble(), source.readDouble());
+    }
+
+    @Override
+    public ParseGeoPoint[] newArray(int size) {
+      return new ParseGeoPoint[size];
+    }
+  };
 }

--- a/Parse/src/main/java/com/parse/ParseGeoPoint.java
+++ b/Parse/src/main/java/com/parse/ParseGeoPoint.java
@@ -70,6 +70,20 @@ public class ParseGeoPoint implements Parcelable {
     this(point.getLatitude(), point.getLongitude());
   }
 
+
+  /**
+   * Creates a new point instance from a Parcel {@code source}. This is used when unparceling a
+   * ParseGeoPoint. Subclasses that need Parcelable behavior should provide their own
+   * {@link android.os.Parcelable.Creator} and override this constructor.
+   *
+   * @param source
+   *          The recovered parcel.
+   */
+  protected ParseGeoPoint(Parcel source) {
+    setLatitude(source.readDouble());
+    setLongitude(source.readDouble());
+  }
+
   /**
    * Set latitude. Valid range is (-90.0, 90.0). Extremes should not be used.
    * 
@@ -285,7 +299,7 @@ public class ParseGeoPoint implements Parcelable {
   public final static Creator<ParseGeoPoint> CREATOR = new Creator<ParseGeoPoint>() {
     @Override
     public ParseGeoPoint createFromParcel(Parcel source) {
-      return new ParseGeoPoint(source.readDouble(), source.readDouble());
+      return new ParseGeoPoint(source);
     }
 
     @Override

--- a/Parse/src/main/java/com/parse/ParseGeoPoint.java
+++ b/Parse/src/main/java/com/parse/ParseGeoPoint.java
@@ -70,16 +70,26 @@ public class ParseGeoPoint implements Parcelable {
     this(point.getLatitude(), point.getLongitude());
   }
 
-
   /**
-   * Creates a new point instance from a Parcel {@code source}. This is used when unparceling a
+   * Creates a new point instance from a {@link Parcel} source. This is used when unparceling a
    * ParseGeoPoint. Subclasses that need Parcelable behavior should provide their own
    * {@link android.os.Parcelable.Creator} and override this constructor.
    *
-   * @param source
-   *          The recovered parcel.
+   * @param source The recovered parcel.
    */
   protected ParseGeoPoint(Parcel source) {
+    this(source, ParseParcelDecoder.get());
+  }
+
+  /**
+   * Creates a new point instance from a {@link Parcel} using the given {@link ParseParcelDecoder}.
+   * The decoder is currently unused, but it might be in the future, plus this is the pattern we
+   * are using in parcelable classes.
+   *
+   * @param source the parcel
+   * @param decoder the decoder
+   */
+  ParseGeoPoint(Parcel source, ParseParcelDecoder decoder) {
     setLatitude(source.readDouble());
     setLongitude(source.readDouble());
   }
@@ -292,6 +302,10 @@ public class ParseGeoPoint implements Parcelable {
 
   @Override
   public void writeToParcel(Parcel dest, int flags) {
+    writeToParcel(dest, ParseParcelEncoder.get());
+  }
+
+  void writeToParcel(Parcel dest, ParseParcelEncoder encoder) {
     dest.writeDouble(latitude);
     dest.writeDouble(longitude);
   }
@@ -299,7 +313,7 @@ public class ParseGeoPoint implements Parcelable {
   public final static Creator<ParseGeoPoint> CREATOR = new Creator<ParseGeoPoint>() {
     @Override
     public ParseGeoPoint createFromParcel(Parcel source) {
-      return new ParseGeoPoint(source);
+      return new ParseGeoPoint(source, ParseParcelDecoder.get());
     }
 
     @Override

--- a/Parse/src/main/java/com/parse/ParseParcelDecoder.java
+++ b/Parse/src/main/java/com/parse/ParseParcelDecoder.java
@@ -62,6 +62,9 @@ import java.util.Map;
       case ParseParcelEncoder.TYPE_FILE:
         return new ParseFile(source, this);
 
+      case ParseParcelEncoder.TYPE_GEOPOINT:
+        return new ParseGeoPoint(source, this);
+
       case ParseParcelEncoder.TYPE_ACL:
         return new ParseACL(source, this);
 

--- a/Parse/src/main/java/com/parse/ParseParcelEncoder.java
+++ b/Parse/src/main/java/com/parse/ParseParcelEncoder.java
@@ -41,7 +41,7 @@ import java.util.Map;
     return ParseEncoder.isValidType(value);
   }
 
-  /* package */ final static String TYPE_OBJECT = "ParseObject";
+  /* package */ final static String TYPE_OBJECT = "Object";
   /* package */ final static String TYPE_POINTER = "Pointer";
   /* package */ final static String TYPE_DATE = "Date";
   /* package */ final static String TYPE_BYTES = "Bytes";
@@ -53,7 +53,8 @@ import java.util.Map;
   /* package */ final static String TYPE_NULL = "Null";
   /* package */ final static String TYPE_NATIVE = "Native";
   /* package */ final static String TYPE_OP = "Operation";
-  /* package */ final static String TYPE_FILE = "ParseFile";
+  /* package */ final static String TYPE_FILE = "File";
+  /* package */ final static String TYPE_GEOPOINT = "GeoPoint";
 
   public void encode(Object object, Parcel dest) {
     try {
@@ -80,7 +81,8 @@ import java.util.Map;
         ((ParseFile) object).writeToParcel(dest, this);
 
       } else if (object instanceof ParseGeoPoint) {
-        throw new IllegalArgumentException("Not supported yet");
+        dest.writeString(TYPE_GEOPOINT);
+        ((ParseGeoPoint) object).writeToParcel(dest, this);
 
       } else if (object instanceof ParseACL) {
         dest.writeString(TYPE_ACL);

--- a/Parse/src/test/java/com/parse/ParseGeoPointTest.java
+++ b/Parse/src/test/java/com/parse/ParseGeoPointTest.java
@@ -18,7 +18,7 @@ import org.robolectric.annotation.Config;
 import static org.junit.Assert.*;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 23)
+@Config(constants = BuildConfig.class, sdk = TestHelper.ROBOLECTRIC_SDK_VERSION)
 public class ParseGeoPointTest {
 
   @Test

--- a/Parse/src/test/java/com/parse/ParseGeoPointTest.java
+++ b/Parse/src/test/java/com/parse/ParseGeoPointTest.java
@@ -8,10 +8,17 @@
  */
 package com.parse;
 
+import android.os.Parcel;
+
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.*;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 23)
 public class ParseGeoPointTest {
 
   @Test
@@ -29,5 +36,16 @@ public class ParseGeoPointTest {
     ParseGeoPoint copy = new ParseGeoPoint(point);
     assertEquals(lat, copy.getLatitude(), 0);
     assertEquals(lng, copy.getLongitude(), 0);
+  }
+
+  @Test
+  public void testParcelable() {
+    ParseGeoPoint point = new ParseGeoPoint(30d, 50d);
+    Parcel parcel = Parcel.obtain();
+    point.writeToParcel(parcel, 0);
+    parcel.setDataPosition(0);
+    point = ParseGeoPoint.CREATOR.createFromParcel(parcel);
+    assertEquals(point.getLatitude(), 30d, 0);
+    assertEquals(point.getLongitude(), 50d, 0);
   }
 }

--- a/Parse/src/test/java/com/parse/ParseObjectTest.java
+++ b/Parse/src/test/java/com/parse/ParseObjectTest.java
@@ -497,7 +497,6 @@ public class ParseObjectTest {
 
   @Test
   public void testParcelable() throws Exception {
-    // TODO test ParseGeoPoint after merge
     ParseObject object = ParseObject.createWithoutData("Test", "objectId");
     object.isDeleted = true;
     object.put("long", 200L);
@@ -531,6 +530,9 @@ public class ParseObjectTest {
     // File
     ParseFile file = new ParseFile(new ParseFile.State.Builder().url("fileUrl").build());
     object.put("file", file);
+    // GeoPoint
+    ParseGeoPoint point = new ParseGeoPoint(30d, 50d);
+    object.put("point", point);
 
     Parcel parcel = Parcel.obtain();
     object.writeToParcel(parcel, 0);
@@ -557,6 +559,8 @@ public class ParseObjectTest {
     assertEquals(newRel.getKnownObjects().size(), rel.getKnownObjects().size());
     newRel.hasKnownObject(related);
     assertEquals(newObject.getParseFile("file").getUrl(), object.getParseFile("file").getUrl());
+    assertEquals(newObject.getParseGeoPoint("point").getLatitude(),
+            object.getParseGeoPoint("point").getLatitude(), 0);
   }
 
   @Test


### PR DESCRIPTION
As per title. It’s the easiest step in bringing Parcelable into the SDK.