### PR TITLE
Implementing Parcelable in ParseFile

### DIFF
--- a/Parse/src/main/java/com/parse/ParseFile.java
+++ b/Parse/src/main/java/com/parse/ParseFile.java
@@ -225,7 +225,7 @@ public class ParseFile implements Parcelable {
   }
 
   /**
-   * Creates a new file instance from a Parcel {@code source}. This is used when unparceling
+   * Creates a new file instance from a {@link Parcel} source. This is used when unparceling
    * a non-dirty ParseFile. Subclasses that need Parcelable behavior should provide their own
    * {@link android.os.Parcelable.Creator} and override this constructor.
    *
@@ -233,6 +233,17 @@ public class ParseFile implements Parcelable {
    *          the source Parcel
    */
   protected ParseFile(Parcel source) {
+    this(source, ParseParcelDecoder.get());
+  }
+
+  /**
+   * Creates a new file instance from a {@link Parcel} using the given {@link ParseParcelDecoder}.
+   * The decoder is currently unused, but it might be in the future, plus this is the pattern we
+   * are using in parcelable classes.
+   * @param source the parcel
+   * @param decoder the decoder
+   */
+  ParseFile(Parcel source, ParseParcelDecoder decoder) {
     this(new State.Builder()
           .url(source.readString())
           .name(source.readString())
@@ -732,6 +743,10 @@ public class ParseFile implements Parcelable {
 
   @Override
   public void writeToParcel(Parcel dest, int flags) {
+    writeToParcel(dest, ParseParcelEncoder.get());
+  }
+
+  void writeToParcel(Parcel dest, ParseParcelEncoder encoder) {
     if (isDirty()) {
       throw new RuntimeException("Unable to parcel an unsaved ParseFile.");
     }

--- a/Parse/src/main/java/com/parse/ParseParcelDecoder.java
+++ b/Parse/src/main/java/com/parse/ParseParcelDecoder.java
@@ -59,6 +59,9 @@ import java.util.Map;
       case ParseParcelEncoder.TYPE_OP:
         return ParseFieldOperations.decode(source, this);
 
+      case ParseParcelEncoder.TYPE_FILE:
+        return new ParseFile(source, this);
+
       case ParseParcelEncoder.TYPE_ACL:
         return new ParseACL(source, this);
 

--- a/Parse/src/main/java/com/parse/ParseParcelEncoder.java
+++ b/Parse/src/main/java/com/parse/ParseParcelEncoder.java
@@ -53,6 +53,7 @@ import java.util.Map;
   /* package */ final static String TYPE_NULL = "Null";
   /* package */ final static String TYPE_NATIVE = "Native";
   /* package */ final static String TYPE_OP = "Operation";
+  /* package */ final static String TYPE_FILE = "ParseFile";
 
   public void encode(Object object, Parcel dest) {
     try {
@@ -75,7 +76,8 @@ import java.util.Map;
         ((ParseFieldOperation) object).encode(dest, this);
 
       } else if (object instanceof ParseFile) {
-        throw new IllegalArgumentException("Not supported yet");
+        dest.writeString(TYPE_FILE);
+        ((ParseFile) object).writeToParcel(dest, this);
 
       } else if (object instanceof ParseGeoPoint) {
         throw new IllegalArgumentException("Not supported yet");

--- a/Parse/src/test/java/com/parse/ParseFileTest.java
+++ b/Parse/src/test/java/com/parse/ParseFileTest.java
@@ -8,13 +8,18 @@
  */
 package com.parse;
 
+import android.os.Parcel;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.io.File;
 import java.io.InputStream;
@@ -36,6 +41,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 23)
 public class ParseFileTest {
 
   @Rule
@@ -490,6 +497,33 @@ public class ParseFileTest {
     for (int i = 0; i < getDataTasks.size(); i++ ) {
       assertTrue("Task #" + i + " was not cancelled", getDataTasks.get(i).isCancelled());
     }
+  }
+
+  @Test
+  public void testParcelable() {
+    String mime = "mime";
+    String name = "name";
+    String url = "url";
+    ParseFile file = new ParseFile(new ParseFile.State.Builder()
+        .name(name)
+        .mimeType(mime)
+        .url(url)
+        .build());
+    Parcel parcel = Parcel.obtain();
+    file.writeToParcel(parcel, 0);
+    parcel.setDataPosition(0);
+    file = ParseFile.CREATOR.createFromParcel(parcel);
+    assertEquals(file.getName(), name);
+    assertEquals(file.getUrl(), url);
+    assertEquals(file.getState().mimeType(), mime);
+    assertFalse(file.isDirty());
+  }
+
+  @Test( expected = RuntimeException.class )
+  public void testDontParcelIfDirty() {
+    ParseFile file = new ParseFile(new ParseFile.State.Builder().build());
+    Parcel parcel = Parcel.obtain();
+    file.writeToParcel(parcel, 0);
   }
 
   // TODO(grantland): testEncode

--- a/Parse/src/test/java/com/parse/ParseFileTest.java
+++ b/Parse/src/test/java/com/parse/ParseFileTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class, sdk = 23)
+@Config(constants = BuildConfig.class, sdk = TestHelper.ROBOLECTRIC_SDK_VERSION)
 public class ParseFileTest {
 
   @Rule

--- a/Parse/src/test/java/com/parse/ParseObjectTest.java
+++ b/Parse/src/test/java/com/parse/ParseObjectTest.java
@@ -497,7 +497,7 @@ public class ParseObjectTest {
 
   @Test
   public void testParcelable() throws Exception {
-    // TODO test ParseGeoPoint and ParseFile after merge
+    // TODO test ParseGeoPoint after merge
     ParseObject object = ParseObject.createWithoutData("Test", "objectId");
     object.isDeleted = true;
     object.put("long", 200L);
@@ -528,6 +528,9 @@ public class ParseObjectTest {
     ParseRelation<ParseObject> rel = new ParseRelation<>(object, "relation");
     rel.add(related);
     object.put("relation", rel);
+    // File
+    ParseFile file = new ParseFile(new ParseFile.State.Builder().url("fileUrl").build());
+    object.put("file", file);
 
     Parcel parcel = Parcel.obtain();
     object.writeToParcel(parcel, 0);
@@ -553,6 +556,7 @@ public class ParseObjectTest {
     assertEquals(newRel.getKey(), rel.getKey());
     assertEquals(newRel.getKnownObjects().size(), rel.getKnownObjects().size());
     newRel.hasKnownObject(related);
+    assertEquals(newObject.getParseFile("file").getUrl(), object.getParseFile("file").getUrl());
   }
 
   @Test


### PR DESCRIPTION
ParseFile Parcelable implementation. With respect to #557 this

- does not parcel the whole byte array
- throws if file is not saved
- safely parcels strings that might be null