### PR TITLE
Robolectric: replace deprecated code & minor optimization

### DIFF
--- a/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
+++ b/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
@@ -8,8 +8,6 @@
  */
 package com.parse;
 
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 import com.parse.http.ParseNetworkInterceptor;
@@ -19,7 +17,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowPackageManager;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -34,7 +31,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class)
@@ -188,11 +184,7 @@ public class ParseClientConfigurationTest {
 
   private Bundle setupMockMetaData() throws Exception {
     Bundle metaData = mock(Bundle.class);
-    ShadowPackageManager packageManager = shadowOf(RuntimeEnvironment.application.getPackageManager());
-    ApplicationInfo info = packageManager.getApplicationInfo(
-        RuntimeEnvironment.application.getPackageName(),
-        PackageManager.GET_META_DATA);
-    info.metaData = metaData;
+    RuntimeEnvironment.application.getApplicationInfo().metaData = metaData;
     return metaData;
   }
 

--- a/Parse/src/test/java/com/parse/ParseInstallationTest.java
+++ b/Parse/src/test/java/com/parse/ParseInstallationTest.java
@@ -9,7 +9,6 @@
 package com.parse;
 
 import android.content.Context;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
@@ -20,7 +19,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.res.builder.RobolectricPackageManager;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -34,9 +32,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -334,11 +330,8 @@ public class ParseInstallationTest {
             mock(ParseCurrentInstallationController.class);
     when(controller.isCurrent(any(ParseInstallation.class))).thenReturn(true);
     ParseCorePlugins.getInstance().registerCurrentInstallationController(controller);
-    // Mock package manager
-    RobolectricPackageManager packageManager =
-            spy(RuntimeEnvironment.getRobolectricPackageManager());
-    doReturn("parseTest").when(packageManager).getApplicationLabel(any(ApplicationInfo.class));
-    RuntimeEnvironment.setRobolectricPackageManager(packageManager);
+    // Mock App Name
+    RuntimeEnvironment.application.getApplicationInfo().name = "parseTest";
     ParsePlugins.Android plugins = mock(ParsePlugins.Android.class);
     // Mock installationId
     InstallationId installationId = mock(InstallationId.class);


### PR DESCRIPTION
`RuntimeEnvironment.getRobolectricPackageManager()` and `RuntimeEnvironment.setRobolectricPackageManager(packageManager)` are deprecated in Robolectric `3.2` and will be removed in `3.4`
http://robolectric.org/migrating/