### PR TITLE
Allow the GcmBroadcastReceiver to be subclassed

### DIFF
--- a/Parse/src/main/java/com/parse/GcmBroadcastReceiver.java
+++ b/Parse/src/main/java/com/parse/GcmBroadcastReceiver.java
@@ -11,31 +11,17 @@ package com.parse;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-
-import java.util.HashSet;
-import java.util.Set;
+import android.support.annotation.CallSuper;
 
 /**
  * @exclude
  */
 public class GcmBroadcastReceiver extends BroadcastReceiver {
 
-    private final Set<BroadcastReceiver> subReceivers = new HashSet<>();
-
     @Override
-    public final void onReceive(Context context, Intent intent) {
+    @CallSuper
+    public void onReceive(Context context, Intent intent) {
         ServiceUtils.runWakefulIntentInService(context, intent, PushService.class);
-        for (BroadcastReceiver broadcastReceiver : subReceivers) {
-            broadcastReceiver.onReceive(context, intent);
-        }
-    }
-
-    protected final void addBroadcastReceiver(BroadcastReceiver broadcastReceiver) {
-        subReceivers.add(broadcastReceiver);
-    }
-
-    protected final void removeBroadcastReceiver(BroadcastReceiver broadcastReceiver) {
-        subReceivers.remove(broadcastReceiver);
     }
 
 }

--- a/Parse/src/main/java/com/parse/GcmBroadcastReceiver.java
+++ b/Parse/src/main/java/com/parse/GcmBroadcastReceiver.java
@@ -17,11 +17,9 @@ import android.support.annotation.CallSuper;
  * @exclude
  */
 public class GcmBroadcastReceiver extends BroadcastReceiver {
-
-    @Override
-    @CallSuper
-    public void onReceive(Context context, Intent intent) {
-        ServiceUtils.runWakefulIntentInService(context, intent, PushService.class);
-    }
-
+  @Override
+  @CallSuper
+  public void onReceive(Context context, Intent intent) {
+    ServiceUtils.runWakefulIntentInService(context, intent, PushService.class);
+  }
 }

--- a/Parse/src/main/java/com/parse/GcmBroadcastReceiver.java
+++ b/Parse/src/main/java/com/parse/GcmBroadcastReceiver.java
@@ -12,12 +12,30 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * @exclude
  */
 public class GcmBroadcastReceiver extends BroadcastReceiver {
-  @Override
-  public final void onReceive(Context context, Intent intent) {
-    ServiceUtils.runWakefulIntentInService(context, intent, PushService.class);
-  }
+
+    private final Set<BroadcastReceiver> subReceivers = new HashSet<>();
+
+    @Override
+    public final void onReceive(Context context, Intent intent) {
+        ServiceUtils.runWakefulIntentInService(context, intent, PushService.class);
+        for (BroadcastReceiver broadcastReceiver : subReceivers) {
+            broadcastReceiver.onReceive(context, intent);
+        }
+    }
+
+    protected final void addBroadcastReceiver(BroadcastReceiver broadcastReceiver) {
+        subReceivers.add(broadcastReceiver);
+    }
+
+    protected final void removeBroadcastReceiver(BroadcastReceiver broadcastReceiver) {
+        subReceivers.remove(broadcastReceiver);
+    }
+
 }

--- a/Parse/src/main/java/com/parse/ManifestInfo.java
+++ b/Parse/src/main/java/com/parse/ManifestInfo.java
@@ -416,34 +416,32 @@ import java.util.List;
     return true;
   }
 
-  private static boolean checkResolveInfo(Class<? extends BroadcastReceiver> clazz, List<ResolveInfo> infoList) {
+  private static boolean checkResolveInfo(Class<? extends BroadcastReceiver> clazz, List<ResolveInfo> infoList, String permission) {
     for (ResolveInfo info : infoList) {
-      if (info.activityInfo != null && clazz.getCanonicalName().equals(info.activityInfo.name)) {
-        return true;
+      if (info.activityInfo != null) {
+        final Class resolveInfoClass;
+        try {
+          resolveInfoClass = Class.forName(info.activityInfo.name);
+        } catch (ClassNotFoundException e) {
+          break;
+        }
+        if (clazz.isAssignableFrom(resolveInfoClass) && (permission == null || permission.equals(info.activityInfo.permission))) {
+            return true;
+        }
       }
     }
 
     return false;
   }
 
-  private static boolean checkReceiver(Class<? extends BroadcastReceiver> clazz, String permission, Intent[] intents) {    
-    ActivityInfo receiver = getReceiverInfo(clazz); 
-
-    if (receiver == null) {
-      return false;
-    }
-    
-    if (permission != null && !permission.equals(receiver.permission)) {
-      return false;
-    }
-    
+  private static boolean checkReceiver(Class<? extends BroadcastReceiver> clazz, String permission, Intent[] intents) {
     for (Intent intent : intents) {
       List<ResolveInfo> receivers = getPackageManager().queryBroadcastReceivers(intent, 0);
       if (receivers.isEmpty()) {
         return false;
       }
 
-      if (!checkResolveInfo(clazz, receivers)) {
+      if (!checkResolveInfo(clazz, receivers, permission)) {
         return false;
       }
     }


### PR DESCRIPTION
You can only define one Broadcast Receiver to act as a GCM receiver.
In our case, we want to receive pushes from Parse and another provider. So I was going to write a Proxy that wrap both receivers.

But the Parse SDK prevent that by doing a strong validation of the Manifest. (https://github.com/parse-community/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ManifestInfo.java#L446-L448)
The GCM receiver defined need to be explicitly an instance of GcmBroadcastReceiver.
And that class can't be extended as the onReceive method is final.
(If the validations do not pass, the PushType is None and the registration will not happen) (https://github.com/parse-community/Parse-SDK-Android/blob/master/Parse/src/main/java/com/parse/ManifestInfo.java#L212-L214)

The current PR is a proposition.
But there are many solutions to my problem.
- Remove the final
- Remove the strong validation
- other suggestion