### PR TITLE
Do not initialize when parse is already initialized

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -34,6 +34,8 @@ import okhttp3.OkHttpClient;
  * library.
  */
 public class Parse {
+  private static final String TAG = "com.parse.Parse";
+
   /**
    * Represents an opaque configuration for the {@code Parse} SDK configuration.
    */
@@ -359,6 +361,10 @@ public class Parse {
   }
 
   public static void initialize(Configuration configuration) {
+    if (isInitialized()) {
+      PLog.w(TAG, "Parse is already initialized");
+      return;
+    }
     // NOTE (richardross): We will need this here, as ParsePlugins uses the return value of
     // isLocalDataStoreEnabled() to perform additional behavior.
     isLocalDatastoreEnabled = configuration.localDataStoreEnabled;

--- a/Parse/src/main/java/com/parse/ParsePlugins.java
+++ b/Parse/src/main/java/com/parse/ParsePlugins.java
@@ -26,6 +26,7 @@ class ParsePlugins {
     private static final String INSTALLATION_ID_LOCATION = "installationId";
 
     private static final Object LOCK = new Object();
+    private static final String TAG = "com.parse.ParsePlugins";
     private static ParsePlugins instance;
 
     // TODO(grantland): Move towards a Config/Builder parameter pattern to allow other configurations
@@ -37,7 +38,8 @@ class ParsePlugins {
     static void set(ParsePlugins plugins) {
         synchronized (LOCK) {
             if (instance != null) {
-                throw new IllegalStateException("ParsePlugins is already initialized");
+                PLog.w(TAG, "ParsePlugins is already initialized");
+                return;
             }
             instance = plugins;
         }

--- a/Parse/src/main/java/com/parse/ParsePlugins.java
+++ b/Parse/src/main/java/com/parse/ParsePlugins.java
@@ -26,7 +26,6 @@ class ParsePlugins {
     private static final String INSTALLATION_ID_LOCATION = "installationId";
 
     private static final Object LOCK = new Object();
-    private static final String TAG = "com.parse.ParsePlugins";
     private static ParsePlugins instance;
 
     // TODO(grantland): Move towards a Config/Builder parameter pattern to allow other configurations
@@ -38,8 +37,7 @@ class ParsePlugins {
     static void set(ParsePlugins plugins) {
         synchronized (LOCK) {
             if (instance != null) {
-                PLog.w(TAG, "ParsePlugins is already initialized");
-                return;
+                throw new IllegalStateException("ParsePlugins is already initialized");
             }
             instance = plugins;
         }


### PR DESCRIPTION
If Parse is initialized in the application.
An IllegalStateException might be thrown when unit testing with Robolectric framework.

for example
MyApplication.java
```java
public class MyApplication extends Application {
  @Override
  public void onCreate() {
    super.onCreate();
    Parse.initialize(this);
  }
}
```

SomeTest.java
```java
@RunWith(RobolectricTestRunner.class)
@Config(constants = BuildConfig.class)
public class SomeTest {

  @Test
  public void test1() {
    ...
  }

  @Test
  public void test2() {
    ...
  }

}
```

Will get `IllegalStateException: ParsePlugins is already initialized` because of Robolectric setup application twice in the same testing session.

I think it would be better not to throw an exception when init parse more than once, just issue a warning log and do nothing.

It does not seems to be Robolectric's issue.
https://github.com/robolectric/robolectric/issues/595
https://github.com/robolectric/robolectric/issues/1981
https://github.com/robolectric/robolectric/issues/2456