### PR TITLE
Fix encoding nested objects

### DIFF
--- a/Parse/src/main/java/com/parse/ParseObjectParcelEncoder.java
+++ b/Parse/src/main/java/com/parse/ParseObjectParcelEncoder.java
@@ -27,6 +27,7 @@ import java.util.Set;
     if (ids.contains(id)) {
       encodePointer(object.getClassName(), id, dest);
     } else {
+      ids.add(id);
       super.encodeParseObject(object, dest);
     }
   }


### PR DESCRIPTION
Adds a fundamental line to `ParseObjectParcelEncoder`. Without this there are issues when parceling objects with circular references