### PR TITLE
Remove some unused or unneeded proguard rules

### DIFF
--- a/Parse/release-proguard.pro
+++ b/Parse/release-proguard.pro
@@ -1,29 +1,7 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /usr/local/opt/android-sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# Add any project specific keep options here:
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Keep source file names, line numbers, and Parse class/method names for easier debugging
--keepattributes SourceFile,LineNumberTable
 -keepnames class com.parse.** { *; }
 
 # Required for Parse
 -keepattributes *Annotation*
 -keepattributes Signature
--dontwarn android.net.SSLCertificateSocketFactory
--dontwarn android.app.Notification
--dontwarn com.squareup.**
+# https://github.com/square/okio#proguard
 -dontwarn okio.**


### PR DESCRIPTION
Turns out we don't need a few of these as they were for when we were using a deprecated Notification class from API 23, and the SSLCertificateSocketFactory on other implementations of the Http Client.

In addition, I am removing the lines that keep source files and line numbers, as this should be decided on/configured by the end consumer, as they might not actually want those things to be kept in their end APK. 