### PR TITLE
Add jFrog OSS

### DIFF
--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -296,3 +296,22 @@ publishing {
 }
 
 // End of Bintray plugin
+
+apply plugin: "com.jfrog.artifactory"
+
+artifactory {
+    contextUrl = 'https://oss.jfrog.org'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local' // The Artifactory repository key to publish to
+
+            username = System.getenv('BINTRAY_USER')
+            password = System.getenv('BINTRAY_API_KEY')
+            maven = true
+        }
+        defaults {
+            publishArtifacts = true
+            publications('MyPublication')
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ As of April 5, 2017, Parse, LLC has transferred this code to the parse-community
  [guide]: http://docs.parseplatform.org/android/guide/
 
  [latest]: https://search.maven.org/remote_content?g=com.parse&a=parse-android&v=LATEST
- [snap]: https://oss.sonatype.org/content/repositories/snapshots/
+ [snap]: https://oss.jfrog.org/artifactory/oss-snapshot-local/com/parse/parse-android/
 
  [build-status-svg]: https://travis-ci.org/parse-community/Parse-SDK-Android.svg?branch=master
  [build-status-link]: https://travis-ci.org/parse-community/Parse-SDK-Android

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 }
 
 plugins {
+    id "com.jfrog.artifactory" version "4.4.17"
     id "com.jfrog.bintray" version "1.7.3"
     id 'com.github.ben-manes.versions' version '0.14.0'
 }

--- a/scripts/publish_snapshot.sh
+++ b/scripts/publish_snapshot.sh
@@ -14,7 +14,6 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
   echo "Skipping publishing SNAPSHOT: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'"
 else
   echo "Publishing SNAPSHOT..."
-  ./gradlew uploadArchives
+  ./gradlew artifactoryPublish
   echo "SNAPSHOT published!"
 fi
-


### PR DESCRIPTION
Waiting for Bintray to respond.  All snapshot repos will be moved there afterwards (mostly because I don't want to have two separate POM configurations with Sonatype and Bintray).
* [Sonatype POM](https://github.com/parse-community/Parse-SDK-Android/blob/master/Parse/build.gradle#L138-L165)
* [Bintray POM](https://github.com/parse-community/Parse-SDK-Android/blob/master/Parse/build.gradle#L291-L309)

```
./gradlew artifactoryPublish
```