### PR TITLE
Allow multiple find/count operations on queries. Expose fromNetwork and isRunning

### DIFF
--- a/Parse/src/main/java/com/parse/ParseQuery.java
+++ b/Parse/src/main/java/com/parse/ParseQuery.java
@@ -527,6 +527,12 @@ public class ParseQuery<T extends ParseObject> {
         return this;
       }
 
+      // Used by clear
+      /* package */ Builder<T> clear(String key) {
+        where.remove(key);
+        return this;
+      }
+
       //endregion
 
       //region Order
@@ -2085,6 +2091,18 @@ public class ParseQuery<T extends ParseObject> {
    */
   public String getClassName() {
     return builder.getClassName();
+  }
+
+  /**
+   * Clears constraints related to the given key, if any was set previously.
+   * Order, includes and selected keys are not affected by this operation.
+   *
+   * @param key key to be cleared from current constraints.
+   * @return this, so you can chain this call.
+   */
+  public ParseQuery<T> clear(String key) {
+    builder.clear(key);
+    return this;
   }
 
   /**

--- a/Parse/src/test/java/com/parse/ParseQueryTest.java
+++ b/Parse/src/test/java/com/parse/ParseQueryTest.java
@@ -241,51 +241,6 @@ public class ParseQueryTest {
   }
 
   @Test
-  public void testQueriesFreezeDuringExecution() throws ParseException {
-    ParseObject.registerSubclass(ParseUser.class);
-    TestQueryController controller = new TestQueryController();
-    ParseCorePlugins.getInstance().registerQueryController(controller);
-
-    TaskCompletionSource<Void> tcs = new TaskCompletionSource();
-    controller.await(tcs.getTask());
-
-    ParseQuery<ParseObject> query = ParseQuery.getQuery("TestObject");
-    query.setUser(new ParseUser());
-    Task<Void> task = query.findInBackground().cast();
-
-    try {
-      query.whereEqualTo("foo", "bar");
-      fail("Should've thrown an exception.");
-    } catch (RuntimeException e) {
-      // do nothing
-    }
-
-    try {
-      query.include("foo");
-      fail("Should've thrown an exception.");
-    } catch (RuntimeException e) {
-      // do nothing
-    }
-
-    try {
-      query.orderByAscending("foo");
-      fail("Should've thrown an exception.");
-    } catch (RuntimeException e) {
-      // do nothing
-    }
-
-    try {
-      query.orderByDescending("bar");
-      fail("Should've thrown an exception.");
-    } catch (RuntimeException e) {
-      // do nothing
-    }
-
-    tcs.setResult(null);
-    ParseTaskUtils.wait(task);
-  }
-
-  @Test
   public void testQueryCancellation() throws ParseException {
     TestQueryController controller = new TestQueryController();
     ParseCorePlugins.getInstance().registerQueryController(controller);

--- a/Parse/src/test/java/com/parse/ParseQueryTest.java
+++ b/Parse/src/test/java/com/parse/ParseQueryTest.java
@@ -564,6 +564,18 @@ public class ParseQueryTest {
   }
 
   @Test
+  public void testClear() throws Exception {
+    ParseQuery<ParseObject> query = new ParseQuery<>("Test");
+    query.whereEqualTo("key", "value");
+    query.whereEqualTo("otherKey", "otherValue");
+    verifyCondition(query, "key", "value");
+    verifyCondition(query, "otherKey", "otherValue");
+    query.clear("key");
+    verifyCondition(query, "key", null);
+    verifyCondition(query, "otherKey", "otherValue"); // still.
+  }
+
+  @Test
   public void testOr() throws Exception {
     ParseQuery<ParseObject> query = new ParseQuery<>("Test");
     query.whereEqualTo("key", "value");
@@ -682,6 +694,13 @@ public class ParseQueryTest {
     query.setSkip(5);
 
     assertEquals(5, query.getSkip());
+  }
+
+  private static void verifyCondition(ParseQuery query, String key, Object value) {
+    // We generate a state to verify the content of the builder
+    ParseQuery.State state = query.getBuilder().build();
+    ParseQuery.QueryConstraints queryConstraints = state.constraints();
+    assertEquals(value, queryConstraints.get(key));
   }
 
   private static void verifyCondition(


### PR DESCRIPTION
This:

- Fixes #6 
- Exposes query.fromNetwork() so users can mimic cache policies when LDS is enabled
- Allows one query to perform multiple find() / count() operations concurrently
- Exposes query.isRunning() (this is a new API, if you think it’s not needed I can remove that)
