### PR TITLE
Set the required internet/network permissions in the SDK

### DIFF
--- a/Parse/src/main/AndroidManifest.xml
+++ b/Parse/src/main/AndroidManifest.xml
@@ -7,6 +7,11 @@
   ~ LICENSE file in the root directory of this source tree. An additional grant
   ~ of patent rights can be found in the PATENTS file in the same directory.
   -->
-<manifest package="com.parse">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.parse">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
     <application />
 </manifest>

--- a/ParseStarterProject/src/main/AndroidManifest.xml
+++ b/ParseStarterProject/src/main/AndroidManifest.xml
@@ -10,9 +10,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.parse.starter" >
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <application
         android:name=".StarterApplication"
         android:allowBackup="false"


### PR DESCRIPTION
State `INTERNET` and `ACCESS_NETWORK_STATE` `use-permission` in the SDK level.
Therefore, no longer need to be declared in App AndroidManifest.xml.