### PR TITLE
Exclude extra files

### DIFF
--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -35,6 +35,10 @@ android {
         consumerProguardFiles 'release-proguard.pro'
     }
 
+    packagingOptions {
+        exclude '**/BuildConfig.class'
+    }
+
     lintOptions {
         abortOnError false
     }


### PR DESCRIPTION
We can kill the JAR-related config section later

The original exclude pattern...not sure if we need to reintroduce it except for Manifest.

```
         exclude '**/R.class'
         exclude '**/R\$*.class'
         exclude '**/Manifest.class'
         exclude '**/Manifest\$*.class'
         exclude '**/BuildConfig.class'
     }
```
@hermanliang 