### PR TITLE
Turn these classes to public

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
     - pip install --user codecov
 
 script:
-  - ./gradlew clean testDebugUnitTest jacocoTestReport --info
+  - ./gradlew clean testDebugUnitTest jacocoTestReport
 
 after_success:
   - ./gradlew coveralls

--- a/Parse/src/main/java/com/parse/ParseDecoder.java
+++ b/Parse/src/main/java/com/parse/ParseDecoder.java
@@ -26,7 +26,7 @@ import org.json.JSONObject;
  *
  * @see com.parse.ParseEncoder
  */
-/** package */ class ParseDecoder {
+/** package */ public class ParseDecoder {
 
   // This class isn't really a Singleton, but since it has no state, it's more efficient to get the
   // default instance.

--- a/Parse/src/main/java/com/parse/ParsePlugins.java
+++ b/Parse/src/main/java/com/parse/ParsePlugins.java
@@ -21,7 +21,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-class ParsePlugins {
+public class ParsePlugins {
 
     private static final String INSTALLATION_ID_LOCATION = "installationId";
 

--- a/Parse/src/main/java/com/parse/ParseQuery.java
+++ b/Parse/src/main/java/com/parse/ParseQuery.java
@@ -297,7 +297,7 @@ public class ParseQuery<T extends ParseObject> {
     }
   }
 
-  /* package */ static class State<T extends ParseObject> {
+  /* package */ public static class State<T extends ParseObject> {
 
     /* package */ static class Builder<T extends ParseObject> {
 

--- a/Parse/src/main/java/com/parse/ParseRESTCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTCommand.java
@@ -31,7 +31,7 @@ import bolts.Task;
 /**
  * A helper object to send requests to the server.
  */
-/** package */ class ParseRESTCommand extends ParseRequest<JSONObject> {
+/** package */ public class ParseRESTCommand extends ParseRequest<JSONObject> {
 
   /* package */ static final String HEADER_APPLICATION_ID = "X-Parse-Application-Id";
   /* package */ static final String HEADER_CLIENT_KEY = "X-Parse-Client-Key";

--- a/Parse/src/main/java/com/parse/PointerEncoder.java
+++ b/Parse/src/main/java/com/parse/PointerEncoder.java
@@ -14,7 +14,7 @@ import org.json.JSONObject;
  * Encodes {@link ParseObjects} as pointers. If the object does not have an objectId, throws an
  * exception.
  */
-/** package */ class PointerEncoder extends PointerOrLocalIdEncoder {
+/** package */ public class PointerEncoder extends PointerOrLocalIdEncoder {
 
   // This class isn't really a Singleton, but since it has no state, it's more efficient to get the
   // default instance.


### PR DESCRIPTION
Just tried to change Parse Live Query package name but there actually classes that need to be made public in order to make this possible.  For now, revert to not using BuildConfig in the Parse SDK Android.

```
/Users/rhu/projects/ParseLiveQuery-Android/ParseLiveQuery/src/main/java/com/parse/livequery/Subscription.java:18: error: State is not public in ParseQuery; cannot be accessed from outside package
    private final ParseQuery.State<T> state;
                            ^
/Users/rhu/projects/ParseLiveQuery-Android/ParseLiveQuery/src/main/java/com/parse/livequery/Subscription.java:71: error: State is not public in ParseQuery; cannot be accessed from outside package
    /* package */ ParseQuery.State<T> getQueryState() {
                            ^
/Users/rhu/projects/ParseLiveQuery-Android/ParseLiveQuery/src/main/java/com/parse/livequery/ParseLiveQueryClientImpl.java:7: error: ParseDecoder is not public in com.parse; cannot be accessed from outside package
import com.parse.ParseDecoder;
                ^
/Users/rhu/projects/ParseLiveQuery-Android/ParseLiveQuery/src/main/java/com/parse/livequery/ParseLiveQueryClientImpl.java:9: error: ParsePlugins is not public in com.parse; cannot be accessed from outside package
import com.parse.ParsePlugins;
                ^
/Users/rhu/projects/ParseLiveQuery-Android/ParseLiveQuery/src/main/java/com/parse/livequery/ParseLiveQueryClientImpl.java:11: error: ParseRESTCommand is not public in com.parse; cannot be accessed from outside package
import com.parse.ParseRESTCommand;
                ^
/Users/rhu/projects/ParseLiveQuery-Android/ParseLiveQuery/src/main/java/com/parse/livequery/SubscribeClientOperation.java:5: error: PointerEncoder is not public in com.parse; cannot be accessed from outside package
import com.parse.PointerEncoder;
                ^
/Users/rhu/projects/ParseLiveQuery-Android/ParseLiveQuery/src/main/java/com/parse/livequery/Su`bscribeClientOperation.java:14: error: State is not public in ParseQuery; cannot be accessed from outside package
    private final ParseQuery.State<T> state;
                            ^
/Users/rhu/projects/ParseLiveQuery-Android/ParseLiveQuery/src/main/java/com/parse/livequery/SubscribeClientOperation.java:17: error: State is not public in ParseQuery; cannot be accessed from outside package
    /* package */ SubscribeClientOperation(int requestId, ParseQuery.State<T> state, String sessionToken) {
                                                                    ^
``