### PR TITLE
Add client support for scheduling push notifications

### DIFF
--- a/Parse/src/main/java/com/parse/ParsePush.java
+++ b/Parse/src/main/java/com/parse/ParsePush.java
@@ -73,6 +73,7 @@ public class ParsePush {
             : new ParseQuery<>(new ParseQuery.State.Builder<ParseInstallation>(state.queryState()));
         this.expirationTime = state.expirationTime();
         this.expirationTimeInterval = state.expirationTimeInterval();
+        this.pushTime = state.pushTime();
         this.pushToIOS = state.pushToIOS();
         this.pushToAndroid = state.pushToAndroid();
         // Since in state.build() we check data is not null, we do not need to check it again here.

--- a/Parse/src/main/java/com/parse/ParsePush.java
+++ b/Parse/src/main/java/com/parse/ParsePush.java
@@ -55,6 +55,7 @@ public class ParsePush {
       private ParseQuery<ParseInstallation> query;
       private Long expirationTime;
       private Long expirationTimeInterval;
+      private Long pushTime;
       private Boolean pushToIOS;
       private Boolean pushToAndroid;
       private JSONObject data;
@@ -93,6 +94,18 @@ public class ParsePush {
       public Builder expirationTimeInterval(Long expirationTimeInterval) {
         this.expirationTimeInterval = expirationTimeInterval;
         expirationTime = null;
+        return this;
+      }
+
+      public Builder pushTime(Long pushTime) {
+        if (pushTime != null) {
+          long now = System.currentTimeMillis() / 1000;
+          long twoWeeks = 60*60*24*7*2;
+          checkArgument(pushTime > now, "Scheduled push time can not be in the past");
+          checkArgument(pushTime < now + twoWeeks, "Scheduled push time can not be more than " +
+              "two weeks in the future");
+        }
+        this.pushTime = pushTime;
         return this;
       }
 
@@ -151,6 +164,7 @@ public class ParsePush {
     private final ParseQuery.State<ParseInstallation> queryState;
     private final Long expirationTime;
     private final Long expirationTimeInterval;
+    private final Long pushTime;
     private final Boolean pushToIOS;
     private final Boolean pushToAndroid;
     private final JSONObject data;
@@ -161,6 +175,7 @@ public class ParsePush {
       this.queryState = builder.query == null ? null : builder.query.getBuilder().build();
       this.expirationTime = builder.expirationTime;
       this.expirationTimeInterval = builder.expirationTimeInterval;
+      this.pushTime = builder.pushTime;
       this.pushToIOS = builder.pushToIOS;
       this.pushToAndroid = builder.pushToAndroid;
       // Since in builder.build() we check data is not null, we do not need to check it again here.
@@ -187,6 +202,10 @@ public class ParsePush {
 
     public Long expirationTimeInterval() {
       return expirationTimeInterval;
+    }
+
+    public Long pushTime() {
+      return pushTime;
     }
 
     public Boolean pushToIOS() {
@@ -419,6 +438,14 @@ public class ParsePush {
   public void clearExpiration() {
     builder.expirationTime(null);
     builder.expirationTimeInterval(null);
+  }
+
+  /**
+   * Sets a UNIX epoch timestamp at which this notification should be delivered, in seconds (UTC).
+   * Scheduled time can not be in the past and must be at most two weeks in the future.
+   */
+  public void setPushTime(long time) {
+    builder.pushTime(time);
   }
 
   /**

--- a/Parse/src/main/java/com/parse/ParsePushController.java
+++ b/Parse/src/main/java/com/parse/ParsePushController.java
@@ -43,6 +43,7 @@ import bolts.Task;
       }
     }
     return ParseRESTPushCommand.sendPushCommand(state.queryState(), state.channelSet(), deviceType,
-        state.expirationTime(), state.expirationTimeInterval(), state.data(), sessionToken);
+        state.expirationTime(), state.expirationTimeInterval(), state.pushTime(), state.data(),
+        sessionToken);
   }
 }

--- a/Parse/src/main/java/com/parse/ParseRESTPushCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTPushCommand.java
@@ -23,6 +23,7 @@ import java.util.Set;
   /* package */ final static String KEY_DEVICE_TYPE = "deviceType";
   /* package */ final static String KEY_EXPIRATION_TIME = "expiration_time";
   /* package */ final static String KEY_EXPIRATION_INTERVAL = "expiration_interval";
+  /* package */ final static String KEY_PUSH_TIME = "push_time";
   /* package */ final static String KEY_DATA = "data";
 
   public ParseRESTPushCommand(
@@ -35,7 +36,7 @@ import java.util.Set;
 
   public static ParseRESTPushCommand sendPushCommand(ParseQuery.State<ParseInstallation> query,
   Set<String> targetChannels, String targetDeviceType, Long expirationTime,
-      Long expirationInterval, JSONObject payload, String sessionToken) {
+      Long expirationInterval, Long pushTime, JSONObject payload, String sessionToken) {
     JSONObject parameters = new JSONObject();
     try {
       if (targetChannels != null) {
@@ -63,9 +64,14 @@ import java.util.Set;
         parameters.put(KEY_EXPIRATION_INTERVAL, expirationInterval);
       }
 
+      if (pushTime != null) {
+        parameters.put(KEY_PUSH_TIME, pushTime);
+      }
+
       if (payload != null) {
         parameters.put(KEY_DATA, payload);
       }
+
     } catch (JSONException e) {
       throw new RuntimeException(e);
     }

--- a/Parse/src/test/java/com/parse/ParsePushControllerTest.java
+++ b/Parse/src/test/java/com/parse/ParsePushControllerTest.java
@@ -83,6 +83,7 @@ public class ParsePushControllerTest {
 
     // Verify command
     JSONObject jsonParameters = pushCommand.jsonParameters;
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_PUSH_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_INTERVAL));
     // Verify device type and query
@@ -113,6 +114,7 @@ public class ParsePushControllerTest {
 
     // Verify command
     JSONObject jsonParameters = pushCommand.jsonParameters;
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_PUSH_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_INTERVAL));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_CHANNELS));
     // Verify device type and query
@@ -121,6 +123,36 @@ public class ParsePushControllerTest {
         jsonParameters.getJSONObject(ParseRESTPushCommand.KEY_DATA)
             .getString(ParsePush.KEY_DATA_MESSAGE));
     assertEquals(1400000000, jsonParameters.getLong(ParseRESTPushCommand.KEY_EXPIRATION_TIME));
+  }
+
+  @Test
+  public void testBuildRESTSendPushCommandWithPushTime() throws Exception {
+    ParseHttpClient restClient = mock(ParseHttpClient.class);
+    ParsePushController controller = new ParsePushController(restClient);
+
+    // Build PushState
+    JSONObject data = new JSONObject();
+    data.put(ParsePush.KEY_DATA_MESSAGE, "hello world");
+    long pushTime = System.currentTimeMillis() / 1000 + 1000;
+    ParsePush.State state = new ParsePush.State.Builder()
+        .data(data)
+        .pushTime(pushTime)
+        .build();
+
+    // Build command
+    ParseRESTCommand pushCommand = controller.buildRESTSendPushCommand(state, "sessionToken");
+
+    // Verify command
+    JSONObject jsonParameters = pushCommand.jsonParameters;
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_TIME));
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_INTERVAL));
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_CHANNELS));
+    // Verify device type and query
+    assertEquals("{}", jsonParameters.get(ParseRESTPushCommand.KEY_WHERE).toString());
+    assertEquals("hello world",
+        jsonParameters.getJSONObject(ParseRESTPushCommand.KEY_DATA)
+            .getString(ParsePush.KEY_DATA_MESSAGE));
+    assertEquals(pushTime, jsonParameters.getLong(ParseRESTPushCommand.KEY_PUSH_TIME));
   }
 
   @Test
@@ -141,6 +173,7 @@ public class ParsePushControllerTest {
 
     // Verify command
     JSONObject jsonParameters = pushCommand.jsonParameters;
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_PUSH_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_CHANNELS));
     // Verify device type and query
@@ -172,6 +205,7 @@ public class ParsePushControllerTest {
 
     // Verify command
     JSONObject jsonParameters = pushCommand.jsonParameters;
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_PUSH_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_INTERVAL));
     assertFalse(jsonParameters.getJSONObject(ParseRESTPushCommand.KEY_WHERE)
@@ -206,6 +240,7 @@ public class ParsePushControllerTest {
 
     // Verify command
     JSONObject jsonParameters = pushCommand.jsonParameters;
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_PUSH_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_INTERVAL));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_CHANNELS));
@@ -235,6 +270,7 @@ public class ParsePushControllerTest {
 
     // Verify command
     JSONObject jsonParameters = pushCommand.jsonParameters;
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_PUSH_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_INTERVAL));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_CHANNELS));
@@ -265,6 +301,7 @@ public class ParsePushControllerTest {
 
     // Verify command
     JSONObject jsonParameters = pushCommand.jsonParameters;
+    assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_PUSH_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_TIME));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_EXPIRATION_INTERVAL));
     assertFalse(jsonParameters.has(ParseRESTPushCommand.KEY_CHANNELS));

--- a/Parse/src/test/java/com/parse/ParsePushStateTest.java
+++ b/Parse/src/test/java/com/parse/ParsePushStateTest.java
@@ -54,6 +54,7 @@ public class ParsePushStateTest {
 
     assertEquals(null, state.expirationTime());
     assertEquals(null, state.expirationTimeInterval());
+    assertEquals(null, state.pushTime());
     assertEquals(null, state.channelSet());
     JSONAssert.assertEquals(data, state.data(), JSONCompareMode.NON_EXTENSIBLE);
     assertEquals(null, state.pushToAndroid());
@@ -68,6 +69,7 @@ public class ParsePushStateTest {
     ParsePush.State state = mock(ParsePush.State.class);
     when(state.expirationTime()).thenReturn(1L);
     when(state.expirationTimeInterval()).thenReturn(2L);
+    when(state.pushTime()).thenReturn(3L);
     Set channelSet = Sets.newSet("one", "two");
     when(state.channelSet()).thenReturn(channelSet);
     JSONObject data = new JSONObject();
@@ -82,6 +84,7 @@ public class ParsePushStateTest {
     ParsePush.State copy = new ParsePush.State.Builder(state).build();
     assertSame(1L, copy.expirationTime());
     assertSame(2L, copy.expirationTimeInterval());
+    assertSame(3L, copy.pushTime());
     Set channelSetCopy = copy.channelSet();
     assertNotSame(channelSet, channelSetCopy);
     assertTrue(channelSetCopy.size() == 2 && channelSetCopy.contains("one"));
@@ -147,6 +150,55 @@ public class ParsePushStateTest {
         .build();
 
     assertEquals(100L, state.expirationTimeInterval().longValue());
+  }
+
+  //endregion
+
+  //region testPushTime
+
+  @Test
+  public void testPushTimeNullTime() {
+    ParsePush.State.Builder builder = new ParsePush.State.Builder();
+
+    ParsePush.State state = builder
+        .pushTime(null)
+        .data(new JSONObject())
+        .build();
+
+    assertEquals(null, state.pushTime());
+  }
+
+  @Test
+  public void testPushTimeNormalTime() {
+    ParsePush.State.Builder builder = new ParsePush.State.Builder();
+
+    long time = System.currentTimeMillis() / 1000 + 1000;
+    ParsePush.State state = builder
+        .pushTime(time)
+        .data(new JSONObject())
+        .build();
+
+    assertEquals(time, state.pushTime().longValue());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPushTimeInThePast() {
+    ParsePush.State.Builder builder = new ParsePush.State.Builder();
+
+    ParsePush.State state = builder
+        .pushTime(System.currentTimeMillis() - 1000)
+        .data(new JSONObject())
+        .build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPushTimeTwoWeeksFromNow() {
+    ParsePush.State.Builder builder = new ParsePush.State.Builder();
+
+    ParsePush.State state = builder
+        .pushTime(System.currentTimeMillis() + 60*60*24*7*3)
+        .data(new JSONObject())
+        .build();
   }
 
   //endregion

--- a/Parse/src/test/java/com/parse/ParsePushStateTest.java
+++ b/Parse/src/test/java/com/parse/ParsePushStateTest.java
@@ -186,7 +186,7 @@ public class ParsePushStateTest {
     ParsePush.State.Builder builder = new ParsePush.State.Builder();
 
     ParsePush.State state = builder
-        .pushTime(System.currentTimeMillis() - 1000)
+        .pushTime(System.currentTimeMillis() / 1000 - 1000)
         .data(new JSONObject())
         .build();
   }
@@ -196,7 +196,7 @@ public class ParsePushStateTest {
     ParsePush.State.Builder builder = new ParsePush.State.Builder();
 
     ParsePush.State state = builder
-        .pushTime(System.currentTimeMillis() + 60*60*24*7*3)
+        .pushTime(System.currentTimeMillis() / 1000 + 60*60*24*7*3)
         .data(new JSONObject())
         .build();
   }

--- a/Parse/src/test/java/com/parse/ParsePushTest.java
+++ b/Parse/src/test/java/com/parse/ParsePushTest.java
@@ -206,6 +206,26 @@ public class ParsePushTest {
 
   //endregion
 
+  //region testSetPushTime
+
+  // We only test a basic case here to make sure logic in ParsePush is correct, more comprehensive
+  // builder test cases should be in ParsePushState test
+  @Test
+  public void testSetPushTime() throws Exception {
+    ParsePush push = new ParsePush();
+    long time = System.currentTimeMillis() / 1000 + 1000;
+    push.setPushTime(time);
+
+    // Right now it is hard for us to test a builder, so we build a state to test the builder is
+    // set correctly
+    // We have to set message otherwise build() will throw an exception
+    push.setMessage("message");
+    ParsePush.State state = push.builder.build();
+    assertEquals(time, state.pushTime().longValue());
+  }
+
+  //endregion
+
   //region testSetPushToIOS
 
   // We only test a basic case here to make sure logic in ParsePush is correct, more comprehensive


### PR DESCRIPTION
This adds `ParsePush.setPushTime()` which is already present in other client SDKs.

Seems that `parse-server` will be eventually supporting scheduled pushes so we’ll be ready when it happens.

Fixes #278 .