### PR TITLE
Add Type Polygon to Schema and PolygonContains to query

### DIFF
--- a/Parse/src/main/java/com/parse/ParseDecoder.java
+++ b/Parse/src/main/java/com/parse/ParseDecoder.java
@@ -57,24 +57,24 @@ import org.json.JSONObject;
     }
     return outputMap;
   }
-  
+
   /**
    * Gets the <code>ParseObject</code> another object points to. By default a new
    * object will be created.
    */
   protected ParseObject decodePointer(String className, String objectId) {
-    return ParseObject.createWithoutData(className, objectId); 
+    return ParseObject.createWithoutData(className, objectId);
   }
 
   public Object decode(Object object) {
     if (object instanceof JSONArray) {
       return convertJSONArrayToList((JSONArray) object);
     }
-    
+
     if (!(object instanceof JSONObject)) {
       return object;
     }
-    
+
     JSONObject jsonObject = (JSONObject) object;
 
     String opString = jsonObject.optString("__op", null);
@@ -121,6 +121,20 @@ import org.json.JSONObject;
       return new ParseGeoPoint(latitude, longitude);
     }
 
+    if (typeString.equals("Polygon")) {
+      List<ParseGeoPoint> coordinates = new ArrayList<ParseGeoPoint>();
+      try {
+        JSONArray array = jsonObject.getJSONArray("coordinates");
+        for (int i = 0; i < array.length(); ++i) {
+          JSONArray point = array.getJSONArray(i);
+          coordinates.add(new ParseGeoPoint(point.getDouble(0), point.getDouble(1)));
+        }
+      } catch (JSONException e) {
+        throw new RuntimeException(e);
+      }
+      return new ParsePolygon(coordinates);
+    }
+
     if (typeString.equals("Object")) {
       return ParseObject.fromJSON(jsonObject, null, this);
     }
@@ -132,7 +146,7 @@ import org.json.JSONObject;
     if (typeString.equals("OfflineObject")) {
       throw new RuntimeException("An unexpected offline pointer was encountered.");
     }
-    
+
     return null;
   }
 }

--- a/Parse/src/main/java/com/parse/ParseEncoder.java
+++ b/Parse/src/main/java/com/parse/ParseEncoder.java
@@ -40,6 +40,7 @@ import java.util.Map;
         || value instanceof ParseACL
         || value instanceof ParseFile
         || value instanceof ParseGeoPoint
+        || value instanceof ParsePolygon
         || value instanceof ParseRelation;
   }
 
@@ -81,6 +82,14 @@ import java.util.Map;
         json.put("__type", "GeoPoint");
         json.put("latitude", point.getLatitude());
         json.put("longitude", point.getLongitude());
+        return json;
+      }
+
+      if (object instanceof ParsePolygon) {
+        ParsePolygon polygon = (ParsePolygon) object;
+        JSONObject json = new JSONObject();
+        json.put("__type", "Polygon");
+        json.put("coordinates", polygon.coordinatesToJSONArray());
         return json;
       }
 

--- a/Parse/src/main/java/com/parse/ParseGeoPoint.java
+++ b/Parse/src/main/java/com/parse/ParseGeoPoint.java
@@ -49,7 +49,7 @@ public class ParseGeoPoint implements Parcelable {
 
   /**
    * Creates a new point with the specified latitude and longitude.
-   * 
+   *
    * @param latitude
    *          The point's latitude.
    * @param longitude
@@ -96,7 +96,7 @@ public class ParseGeoPoint implements Parcelable {
 
   /**
    * Set latitude. Valid range is (-90.0, 90.0). Extremes should not be used.
-   * 
+   *
    * @param latitude
    *          The point's latitude.
    */
@@ -116,7 +116,7 @@ public class ParseGeoPoint implements Parcelable {
 
   /**
    * Set longitude. Valid range is (-180.0, 180.0). Extremes should not be used.
-   * 
+   *
    * @param longitude
    *          The point's longitude.
    */
@@ -137,7 +137,7 @@ public class ParseGeoPoint implements Parcelable {
   /**
    * Get distance in radians between this point and another {@code ParseGeoPoint}. This is the
    * smallest angular distance between the two points.
-   * 
+   *
    * @param point
    *          {@code ParseGeoPoint} describing the other point being measured against.
    */
@@ -162,7 +162,7 @@ public class ParseGeoPoint implements Parcelable {
 
   /**
    * Get distance between this point and another {@code ParseGeoPoint} in kilometers.
-   * 
+   *
    * @param point
    *          {@code ParseGeoPoint} describing the other point being measured against.
    */
@@ -172,7 +172,7 @@ public class ParseGeoPoint implements Parcelable {
 
   /**
    * Get distance between this point and another {@code ParseGeoPoint} in kilometers.
-   * 
+   *
    * @param point
    *          {@code ParseGeoPoint} describing the other point being measured against.
    */
@@ -274,7 +274,7 @@ public class ParseGeoPoint implements Parcelable {
    *   times for a fix.
    * * For better battery efficiency and faster location fixes, you can set
    *   {@link Criteria#setPowerRequirement(int)}, however, this will result in lower accuracy.
-   * 
+   *
    * @param timeout
    *          The number of milliseconds to allow before timing out.
    * @param criteria
@@ -288,6 +288,18 @@ public class ParseGeoPoint implements Parcelable {
   public static void getCurrentLocationInBackground(long timeout, Criteria criteria,
       LocationCallback callback) {
     ParseTaskUtils.callbackOnMainThreadAsync(getCurrentLocationInBackground(timeout, criteria), callback);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof ParseGeoPoint)) {
+      return false;
+    }
+    if (obj == this) {
+      return true;
+    }
+    return ((ParseGeoPoint) obj).getLatitude() == latitude &&
+    ((ParseGeoPoint) obj).getLongitude() == longitude;
   }
 
   @Override

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -3458,6 +3458,24 @@ public class ParseObject implements Parcelable {
   }
 
   /**
+   * Access a {@link ParsePolygon} value.
+   *
+   * @param key
+   *          The key to access the value for
+   * @return {@code null} if there is no such key or if it is not a {@link ParsePolygon}.
+   */
+  public ParsePolygon getParsePolygon(String key) {
+    synchronized (mutex) {
+      checkGetAccess(key);
+      Object value = estimatedData.get(key);
+      if (!(value instanceof ParsePolygon)) {
+        return null;
+      }
+      return (ParsePolygon) value;
+    }
+  }
+
+  /**
    * Access the {@link ParseACL} governing this object.
    */
   public ParseACL getACL() {

--- a/Parse/src/main/java/com/parse/ParseParcelDecoder.java
+++ b/Parse/src/main/java/com/parse/ParseParcelDecoder.java
@@ -65,6 +65,9 @@ import java.util.Map;
       case ParseParcelEncoder.TYPE_GEOPOINT:
         return new ParseGeoPoint(source, this);
 
+      case ParseParcelEncoder.TYPE_POLYGON:
+        return new ParsePolygon(source, this);
+          
       case ParseParcelEncoder.TYPE_ACL:
         return new ParseACL(source, this);
 

--- a/Parse/src/main/java/com/parse/ParseParcelEncoder.java
+++ b/Parse/src/main/java/com/parse/ParseParcelEncoder.java
@@ -55,6 +55,7 @@ import java.util.Map;
   /* package */ final static String TYPE_OP = "Operation";
   /* package */ final static String TYPE_FILE = "File";
   /* package */ final static String TYPE_GEOPOINT = "GeoPoint";
+  /* package */ final static String TYPE_POLYGON = "Polygon";
 
   public void encode(Object object, Parcel dest) {
     try {
@@ -83,6 +84,10 @@ import java.util.Map;
       } else if (object instanceof ParseGeoPoint) {
         dest.writeString(TYPE_GEOPOINT);
         ((ParseGeoPoint) object).writeToParcel(dest, this);
+
+      } else if (object instanceof ParsePolygon) {
+        dest.writeString(TYPE_POLYGON);
+        ((ParsePolygon) object).writeToParcel(dest, this);
 
       } else if (object instanceof ParseACL) {
         dest.writeString(TYPE_ACL);

--- a/Parse/src/main/java/com/parse/ParsePolygon.java
+++ b/Parse/src/main/java/com/parse/ParsePolygon.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+package com.parse;
+
+import android.location.Criteria;
+import android.location.Location;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.Locale;
+import java.util.List;
+
+import bolts.Continuation;
+import bolts.Task;
+
+/**
+ * {@code ParsePolygon} represents a set of coordinates that may be associated with a key
+ * in a {@link ParseObject} or used as a reference point for geo queries. This allows proximity
+ * based queries on the key.
+ *
+ * Example:
+ * <pre>
+ * List<ParseGeoPoint> points = new ArrayList<ParseGeoPoint>();
+ * points.add(new ParseGeoPoint(0,0));
+ * points.add(new ParseGeoPoint(0,1));
+ * points.add(new ParseGeoPoint(1,1));
+ * points.add(new ParseGeoPoint(1,0));
+ * ParsePolygon polygon = new ParsePolygon(points);
+ * ParseObject object = new ParseObject("PlaceObject");
+ * object.put("area", polygon);
+ * object.save();
+ * </pre>
+ */
+
+public class ParsePolygon implements Parcelable {
+
+  private List<ParseGeoPoint> coordinates;
+
+  /**
+   * Creates a new polygon with the specified {@link ParseGeoPoint}.
+   *
+   * @param coords
+   *          The polygon's coordinates.
+   */
+  public ParsePolygon(List<ParseGeoPoint> coords) {
+    setCoordinates(coords);
+  }
+
+  /**
+   * Creates a copy of {@code polygon};
+   *
+   * @param polygon
+   *          The polygon to copy.
+   */
+  public ParsePolygon(ParsePolygon polygon) {
+    this(polygon.getCoordinates());
+  }
+
+  /**
+   * Creates a new point instance from a {@link Parcel} source. This is used when unparceling a
+   * ParsePolygon. Subclasses that need Parcelable behavior should provide their own
+   * {@link android.os.Parcelable.Creator} and override this constructor.
+   *
+   * @param source The recovered parcel.
+   */
+  protected ParsePolygon(Parcel source) {
+    this(source, ParseParcelDecoder.get());
+  }
+
+  /**
+   * Creates a new point instance from a {@link Parcel} using the given {@link ParseParcelDecoder}.
+   * The decoder is currently unused, but it might be in the future, plus this is the pattern we
+   * are using in parcelable classes.
+   *
+   * @param source the parcel
+   * @param decoder the decoder
+   */
+  ParsePolygon(Parcel source, ParseParcelDecoder decoder) {
+    setCoordinates(source.readArrayList(null));
+  }
+
+
+  /**
+   * Set coordinates. Valid are Array of GeoPoint, ParseGeoPoint or Location
+   * at least 3 points
+   *
+   * @param coords
+   *          The polygon's coordinates.
+   */
+  public void setCoordinates(List<ParseGeoPoint> coords) {
+    this.coordinates = ParsePolygon._validate(coords);
+  }
+
+  /**
+   * Get coordinates.
+   */
+  public List<ParseGeoPoint> getCoordinates() {
+    return coordinates;
+  }
+
+  /**
+   * Get converts coordinate to JSONArray.
+   */
+  public JSONArray coordinatesToJSONArray() throws JSONException{
+    JSONArray points = new JSONArray();
+    for (ParseGeoPoint coordinate : coordinates) {
+      JSONArray point = new JSONArray();
+      point.put(coordinate.getLatitude());
+      point.put(coordinate.getLongitude());
+      points.put(point);
+    }
+    return points;
+  }
+
+  /**
+   * Checks if this {@code ParsePolygon}; contains {@link ParseGeoPoint}.
+   */
+  public boolean containsPoint(ParseGeoPoint point) {
+    double minX = coordinates.get(0).getLatitude();
+    double maxX = coordinates.get(0).getLatitude();
+    double minY = coordinates.get(0).getLongitude();
+    double maxY = coordinates.get(0).getLongitude();
+
+    for ( int i = 1; i < coordinates.size(); i += 1) {
+        ParseGeoPoint geoPoint = coordinates.get(i);
+        minX = Math.min(geoPoint.getLatitude(), minX);
+        maxX = Math.max(geoPoint.getLatitude(), maxX);
+        minY = Math.min(geoPoint.getLongitude(), minY);
+        maxY = Math.max(geoPoint.getLongitude(), maxY);
+    }
+
+    boolean outside = point.getLatitude() < minX || point.getLatitude() > maxX || point.getLongitude() < minY || point.getLongitude() > maxY;
+    if (outside) {
+        return false;
+    }
+
+    boolean inside = false;
+    for (int i = 0, j = coordinates.size() - 1 ; i < coordinates.size(); j = i++) {
+      double startX = coordinates.get(i).getLatitude();
+      double startY = coordinates.get(i).getLongitude();
+      double endX = coordinates.get(j).getLatitude();
+      double endY = coordinates.get(j).getLongitude();
+
+      boolean intersect = (( startY > point.getLongitude() ) != ( endY > point.getLongitude() ) &&
+          point.getLatitude() < ( endX - startX ) * ( point.getLongitude() - startY ) / ( endY - startY ) + startX);
+
+        if (intersect) {
+            inside = !inside;
+        }
+    }
+    return inside;
+  }
+
+  /**
+   * Throws exception for invalid coordinates.
+   */
+  static List<ParseGeoPoint> _validate(List<ParseGeoPoint> coords) {
+    if (coords.size() < 3) {
+      throw new IllegalArgumentException("Polygon must have at least 3 GeoPoints");
+    }
+    return coords;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof ParsePolygon)) {
+      return false;
+    }
+    if (obj == this) {
+      return true;
+    }
+    ParsePolygon other = (ParsePolygon) obj;
+
+    if (coordinates.size() != other.getCoordinates().size()) {
+      return false;
+    }
+
+    boolean isEqual = true;
+    for (int i = 0; i < coordinates.size(); i += 1) {
+      if (coordinates.get(i).getLatitude() != other.getCoordinates().get(i).getLatitude() ||
+          coordinates.get(i).getLongitude() != other.getCoordinates().get(i).getLongitude()) {
+        isEqual = false;
+        break;
+      }
+    }
+    return isEqual;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(Locale.US, "ParsePolygon: %s", coordinates);
+  }
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel dest, int flags) {
+    writeToParcel(dest, ParseParcelEncoder.get());
+  }
+
+  void writeToParcel(Parcel dest, ParseParcelEncoder encoder) {
+    dest.writeList(coordinates);
+  }
+
+  public final static Creator<ParsePolygon> CREATOR = new Creator<ParsePolygon>() {
+    @Override
+    public ParsePolygon createFromParcel(Parcel source) {
+      return new ParsePolygon(source, ParseParcelDecoder.get());
+    }
+
+    @Override
+    public ParsePolygon[] newArray(int size) {
+      return new ParsePolygon[size];
+    }
+  };
+}

--- a/Parse/src/main/java/com/parse/ParsePolygon.java
+++ b/Parse/src/main/java/com/parse/ParsePolygon.java
@@ -97,7 +97,7 @@ public class ParsePolygon implements Parcelable {
    *          The polygon's coordinates.
    */
   public void setCoordinates(List<ParseGeoPoint> coords) {
-    this.coordinates = ParsePolygon._validate(coords);
+    this.coordinates = ParsePolygon.validate(coords);
   }
 
   /**
@@ -110,7 +110,7 @@ public class ParsePolygon implements Parcelable {
   /**
    * Get converts coordinate to JSONArray.
    */
-  public JSONArray coordinatesToJSONArray() throws JSONException{
+  protected JSONArray coordinatesToJSONArray() throws JSONException{
     JSONArray points = new JSONArray();
     for (ParseGeoPoint coordinate : coordinates) {
       JSONArray point = new JSONArray();
@@ -163,7 +163,7 @@ public class ParsePolygon implements Parcelable {
   /**
    * Throws exception for invalid coordinates.
    */
-  static List<ParseGeoPoint> _validate(List<ParseGeoPoint> coords) {
+  static List<ParseGeoPoint> validate(List<ParseGeoPoint> coords) {
     if (coords.size() < 3) {
       throw new IllegalArgumentException("Polygon must have at least 3 GeoPoints");
     }

--- a/Parse/src/main/java/com/parse/ParseQuery.java
+++ b/Parse/src/main/java/com/parse/ParseQuery.java
@@ -468,6 +468,12 @@ public class ParseQuery<T extends ParseObject> {
         return addCondition(key, "$within", dictionary);
       }
 
+      public Builder<T> whereGeoIntersects(String key, ParseGeoPoint point) {
+        Map<String, ParseGeoPoint> dictionary = new HashMap<>();
+        dictionary.put("$point", point);
+        return addCondition(key, "$geoIntersects", dictionary);
+      }
+
       public Builder<T> addCondition(String key, String condition,
           Collection<? extends Object> value) {
         return addConditionInternal(key, condition, Collections.unmodifiableCollection(value));
@@ -1839,6 +1845,23 @@ public class ParseQuery<T extends ParseObject> {
   public ParseQuery<T> whereWithinGeoBox(
       String key, ParseGeoPoint southwest, ParseGeoPoint northeast) {
     builder.whereWithin(key, southwest, northeast);
+    return this;
+  }
+
+  /**
+   * Add a constraint to the query that requires a particular key's
+   * coordinates that contains a {@link ParseGeoPoint}s
+   *
+   * (Requires parse-server@2.6.0)
+   *
+   * @param key
+   *          The key to be constrained.
+   * @param point
+   *          ParseGeoPoint
+   * @return this, so you can chain this call.
+   */
+  public ParseQuery<T> wherePolygonContains(String key, ParseGeoPoint point) {
+    builder.whereGeoIntersects(key, point);
     return this;
   }
 

--- a/Parse/src/test/java/com/parse/ParseDecoderTest.java
+++ b/Parse/src/test/java/com/parse/ParseDecoderTest.java
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -185,6 +186,34 @@ public class ParseDecoderTest extends ResetPluginsParseTest {
     final double DELTA = 0.00001;
     assertEquals(-20, parseGeoPoint.getLongitude(), DELTA);
     assertEquals(30, parseGeoPoint.getLatitude(), DELTA);
+  }
+
+  @Test
+  public void testPolygonWithoutCoordinates() throws JSONException {
+    JSONObject json = new JSONObject();
+    json.put("__type", "Polygon");
+
+    thrown.expect(RuntimeException.class);
+    ParseDecoder.get().decode(json);
+  }
+
+  @Test
+  public void testPolygon() throws JSONException {
+    List<ParseGeoPoint> points = new ArrayList<ParseGeoPoint>();
+    points.add(new ParseGeoPoint(0,0));
+    points.add(new ParseGeoPoint(0,1));
+    points.add(new ParseGeoPoint(1,1));
+    points.add(new ParseGeoPoint(1,0));
+
+    ParsePolygon polygon = new ParsePolygon(points);
+
+    JSONObject json = new JSONObject();
+    json.put("__type", "Polygon");
+    json.put("coordinates", polygon.coordinatesToJSONArray());
+
+    ParsePolygon parsePolygon = (ParsePolygon) ParseDecoder.get().decode(json);
+    assertNotNull(parsePolygon);
+    assertEquals(polygon.getCoordinates(), parsePolygon.getCoordinates());
   }
 
   @Test

--- a/Parse/src/test/java/com/parse/ParseEncoderTest.java
+++ b/Parse/src/test/java/com/parse/ParseEncoderTest.java
@@ -20,6 +20,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Date;
 import java.util.HashMap;
 
@@ -100,6 +101,21 @@ public class ParseEncoderTest {
     assertEquals("GeoPoint", geoPointJSON.getString("__type"));
     assertEquals(30, geoPointJSON.getDouble("latitude"), DELTA);
     assertEquals(-20, geoPointJSON.getDouble("longitude"), DELTA);
+  }
+
+  @Test
+  public void testParsePolygon() throws JSONException {
+    List<ParseGeoPoint> points = new ArrayList<ParseGeoPoint>();
+    points.add(new ParseGeoPoint(0,0));
+    points.add(new ParseGeoPoint(0,1));
+    points.add(new ParseGeoPoint(1,1));
+    points.add(new ParseGeoPoint(1,0));
+
+    ParsePolygon parsePolygon = new ParsePolygon(points);
+    JSONObject polygonJSON = (JSONObject) testClassObject.encode(parsePolygon);
+    assertNotNull(polygonJSON);
+    assertEquals("Polygon", polygonJSON.getString("__type"));
+    assertEquals(parsePolygon.coordinatesToJSONArray(), polygonJSON.getJSONArray("coordinates"));
   }
 
   @Test

--- a/Parse/src/test/java/com/parse/ParseGeoPointTest.java
+++ b/Parse/src/test/java/com/parse/ParseGeoPointTest.java
@@ -39,6 +39,21 @@ public class ParseGeoPointTest {
   }
 
   @Test
+  public void testEquals() {
+    ParseGeoPoint pointA = new ParseGeoPoint(30d, 50d);
+    ParseGeoPoint pointB = new ParseGeoPoint(30d, 50d);
+    ParseGeoPoint pointC = new ParseGeoPoint(45d, 45d);
+
+    assertTrue(pointA.equals(pointB));
+    assertTrue(pointA.equals(pointA));
+    assertTrue(pointB.equals(pointA));
+
+    assertFalse(pointA.equals(null));
+    assertFalse(pointA.equals(true));
+    assertFalse(pointA.equals(pointC));
+  }
+
+  @Test
   public void testParcelable() {
     ParseGeoPoint point = new ParseGeoPoint(30d, 50d);
     Parcel parcel = Parcel.obtain();

--- a/Parse/src/test/java/com/parse/ParseObjectTest.java
+++ b/Parse/src/test/java/com/parse/ParseObjectTest.java
@@ -365,6 +365,29 @@ public class ParseObjectTest {
   }
 
   @Test
+  public void testGetParsePolygon() throws Exception {
+    ParseObject object = new ParseObject("Test");
+    List<ParseGeoPoint> points = new ArrayList<ParseGeoPoint>();
+    points.add(new ParseGeoPoint(0,0));
+    points.add(new ParseGeoPoint(0,1));
+    points.add(new ParseGeoPoint(1,1));
+    points.add(new ParseGeoPoint(1,0));
+
+    ParsePolygon polygon = new ParsePolygon(points);
+    object.put("key", polygon);
+
+    assertEquals(polygon, object.getParsePolygon("key"));
+  }
+
+  @Test
+  public void testGetParsePolygonWithWrongValue() throws Exception {
+    ParseObject object = new ParseObject("Test");
+    object.put("key", 1);
+
+    assertNull(object.getParsePolygon("key"));
+  }
+
+  @Test
   public void testGetACL() throws Exception {
     ParseObject object = new ParseObject("Test");
     ParseACL acl = new ParseACL();
@@ -491,7 +514,7 @@ public class ParseObjectTest {
 
     assertEquals(0, object.getLong("key"));
   }
-  
+
   //endregion
 
   //region testParcelable

--- a/Parse/src/test/java/com/parse/ParsePolygonTest.java
+++ b/Parse/src/test/java/com/parse/ParsePolygonTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+package com.parse;
+
+import android.os.Parcel;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = TestHelper.ROBOLECTRIC_SDK_VERSION)
+public class ParsePolygonTest {
+
+  @Test
+  public void testConstructors() {
+    List<ParseGeoPoint> arrayPoints = Arrays.asList(
+      new ParseGeoPoint(0,0),
+      new ParseGeoPoint(0,1),
+      new ParseGeoPoint(1,1),
+      new ParseGeoPoint(1,0)
+    );
+
+    List<ParseGeoPoint> listPoints = new ArrayList<ParseGeoPoint>();
+    listPoints.add(new ParseGeoPoint(0,0));
+    listPoints.add(new ParseGeoPoint(0,1));
+    listPoints.add(new ParseGeoPoint(1,1));
+    listPoints.add(new ParseGeoPoint(1,0));
+
+    ParsePolygon polygonList = new ParsePolygon(listPoints);
+    assertEquals(listPoints, polygonList.getCoordinates());
+
+    ParsePolygon polygonArray = new ParsePolygon(arrayPoints);
+    assertEquals(arrayPoints, polygonArray.getCoordinates());
+
+    ParsePolygon copyList = new ParsePolygon(polygonList);
+    assertEquals(polygonList.getCoordinates(), copyList.getCoordinates());
+
+    ParsePolygon copyArray = new ParsePolygon(polygonArray);
+    assertEquals(polygonArray.getCoordinates(), copyArray.getCoordinates());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testThreePointMinimum() {
+    ParseGeoPoint p1 = new ParseGeoPoint(0,0);
+    ParseGeoPoint p2 = new ParseGeoPoint(0,1);
+    List<ParseGeoPoint> points = Arrays.asList(p1,p2);
+    ParsePolygon polygon = new ParsePolygon(points);
+  }
+
+  @Test
+  public void testEquality() {
+    List<ParseGeoPoint> points = new ArrayList<ParseGeoPoint>();
+    points.add(new ParseGeoPoint(0,0));
+    points.add(new ParseGeoPoint(0,1));
+    points.add(new ParseGeoPoint(1,1));
+    points.add(new ParseGeoPoint(1,0));
+
+    List<ParseGeoPoint> diff = new ArrayList<ParseGeoPoint>();
+    diff.add(new ParseGeoPoint(0,0));
+    diff.add(new ParseGeoPoint(0,10));
+    diff.add(new ParseGeoPoint(10,10));
+    diff.add(new ParseGeoPoint(10,0));
+    diff.add(new ParseGeoPoint(0,0));
+
+    ParsePolygon polygonA = new ParsePolygon(points);
+    ParsePolygon polygonB = new ParsePolygon(points);
+    ParsePolygon polygonC = new ParsePolygon(diff);
+
+    assertTrue(polygonA.equals(polygonB));
+    assertTrue(polygonA.equals(polygonA));
+    assertTrue(polygonB.equals(polygonA));
+
+    assertFalse(polygonA.equals(null));
+    assertFalse(polygonA.equals(true));
+    assertFalse(polygonA.equals(polygonC));
+  }
+
+  @Test
+  public void testContainsPoint() {
+    List<ParseGeoPoint> points = new ArrayList<ParseGeoPoint>();
+    points.add(new ParseGeoPoint(0,0));
+    points.add(new ParseGeoPoint(0,1));
+    points.add(new ParseGeoPoint(1,1));
+    points.add(new ParseGeoPoint(1,0));
+
+    ParseGeoPoint inside = new ParseGeoPoint(0.5,0.5);
+    ParseGeoPoint outside = new ParseGeoPoint(10,10);
+
+    ParsePolygon polygon = new ParsePolygon(points);
+
+    assertTrue(polygon.containsPoint(inside));
+    assertFalse(polygon.containsPoint(outside));
+  }
+
+  @Test
+  public void testParcelable() {
+    List<ParseGeoPoint> points = new ArrayList<ParseGeoPoint>();
+    points.add(new ParseGeoPoint(0,0));
+    points.add(new ParseGeoPoint(0,1));
+    points.add(new ParseGeoPoint(1,1));
+    points.add(new ParseGeoPoint(1,0));
+    ParsePolygon polygon = new ParsePolygon(points);
+    Parcel parcel = Parcel.obtain();
+    polygon.writeToParcel(parcel, 0);
+    parcel.setDataPosition(0);
+    polygon = ParsePolygon.CREATOR.createFromParcel(parcel);
+    assertEquals(polygon.getCoordinates(), points);
+  }
+}

--- a/Parse/src/test/java/com/parse/ParseQueryTest.java
+++ b/Parse/src/test/java/com/parse/ParseQueryTest.java
@@ -531,6 +531,23 @@ public class ParseQueryTest {
   }
 
   @Test
+  public void testWherePolygonContains() throws Exception {
+    ParseQuery<ParseObject> query = new ParseQuery<>("Test");
+    ParseGeoPoint point = new ParseGeoPoint(10, 10);
+
+    query.wherePolygonContains("key", point);
+
+    // We generate a state to verify the content of the builder
+    ParseQuery.State state = query.getBuilder().build();
+    ParseQuery.QueryConstraints queryConstraints = state.constraints();
+    ParseQuery.KeyConstraints keyConstraints =
+        (ParseQuery.KeyConstraints) queryConstraints.get("key");
+    Map map = (Map) keyConstraints.get("$geoIntersects");
+    ParseGeoPoint geoPoint = (ParseGeoPoint) map.get("$point");
+    assertEquals(geoPoint, point);
+  }
+
+  @Test
   public void testWhereWithinRadians() throws Exception {
     ParseQuery<ParseObject> query = new ParseQuery<>("Test");
     ParseGeoPoint point = new ParseGeoPoint(10, 10);
@@ -741,7 +758,7 @@ public class ParseQueryTest {
       assertEquals(map.get(constraintKey), values.get(constraintKey));
     }
   }
-  
+
   //endregion
 
   /**


### PR DESCRIPTION
https://github.com/parse-community/parse-server/pull/3944

I've also added a containsPoint function that can be used for live queries.

ParseGeoPoint was missing equality and tests