### PR TITLE
Add additional getting started info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@
 A library that gives you access to the powerful Parse cloud platform from your Android app.
 For more information about Parse and its features, see [the website][parseplatform.org], [blog][blog] and [getting started][guide].
 
-
-
-
 ## Getting Started
 ### Installation
 - **Option 1:** Gradle
@@ -28,7 +25,7 @@ For more information about Parse and its features, see [the website][parseplatfo
 
 - **Option 2:** Compiling for yourself into JAR/AAR file
 
-  If you want to manually compile the SDK, begin by cloning the repository locally or retrieving the source code for a particular [release](releases). Open the project in Android Studio and run the following commands in the Terminal of Android Studio:
+  If you want to manually compile the SDK, begin by cloning the repository locally or retrieving the source code for a particular [release][releases]. Open the project in Android Studio and run the following commands in the Terminal of Android Studio:
   
   ```
   ./gradlew clean jarRelease
@@ -113,7 +110,7 @@ Results can be found in `Parse/build/reports/`
 Results can be found in `Parse/build/reports/`
 
 ## How Do I Contribute?
-We want to make contributing to this project as easy and transparent as possible. Please refer to the [Contribution Guidelines](contributing).
+We want to make contributing to this project as easy and transparent as possible. Please refer to the [Contribution Guidelines][contributing].
 
 ## Other Parse Projects
 

--- a/README.md
+++ b/README.md
@@ -157,4 +157,4 @@ As of April 5, 2017, Parse, LLC has transferred this code to the parse-community
  [license-link]: https://github.com/parse-community/Parse-SDK-Android/blob/master/LICENSE
 
  [releases]: https://github.com/parse-community/Parse-SDK-Android/releases
- [contributing]: https://github.com/parse-community/Parse-SDK-Android/blob/master/CONTRIBUTING.md
+ [contributing]: CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ For more information about Parse and its features, see [the website][parseplatfo
 
 ## Getting Started
 ### Installation
-- **Gradle**
+- **Option 1:** Gradle
 
-  Add the dependency in Gradle:
+  Add dependency to the application level `build.gradle` file.
 
   ```groovy
   dependencies {
@@ -26,7 +26,7 @@ For more information about Parse and its features, see [the website][parseplatfo
 
   Snapshots of the development version are available in [jFrog's `snapshots` repository][snap].
 
-- **Compiling for yourself**
+- **Option 2:** Compiling for yourself
 
   If you want to manually compile the SDK, begin by cloning the repository locally or retrieving the source code for a particular [release](releases). Open the project in Android Studio and run the following commands:
   
@@ -48,8 +48,65 @@ For more information about Parse and its features, see [the website][parseplatfo
 
     Compiled frameworks will be in 2 archives: `Parse-iOS.zip` and `Parse-OSX.zip` inside the `build/release` folder, and you can link them as you'd please.
     
-    
-    
+ ### Setup
+- **Option 1:** Setup in the Manifest
+
+  You may define `com.parse.SERVER_URL` and `com.parse.APPLICATION_ID` meta-data in your `AndroidManifest.xml`:
+
+  ```
+  <application ...>
+    <meta-data
+      android:name="com.parse.SERVER_URL"
+      android:value="@string/parse_server_url" />
+    <meta-data
+      android:name="com.parse.APPLICATION_ID"
+      android:value="@string/parse_app_id" />
+    ...
+  </application>
+  ```
+  
+  Initialize Parse in a custom class that extends `Application`:
+  ```
+  import com.parse.Parse;
+  import android.app.Application;
+
+  public class App extends Application {
+    @Override
+    public void onCreate() {
+      super.onCreate();
+      Parse.initialize(this);
+    }
+  }
+  ```
+  
+- **Option 2:** Setup in the Application
+  
+  Initialize Parse in a custom class that extends `Application`:
+  ```
+  import com.parse.Parse;
+  import android.app.Application;
+
+  public class App extends Application {
+    @Override
+    public void onCreate() {
+      super.onCreate();
+      Parse.initialize(new Parse.Configuration.Builder(this)
+        .applicationId("YOUR_APP_ID")
+        .server("http://localhost:1337/parse/")
+        .build()
+      );
+    }
+  }
+  ```
+  
+ For either option, the custom `Application` class must be registered in `AndroidManifest.xml`:
+ ```
+ <application
+   android:name=".App"
+   ...>
+   ...
+ </application>
+ ```
 
 ## Download
 Add the dependency in Gradle:

--- a/README.md
+++ b/README.md
@@ -26,27 +26,16 @@ For more information about Parse and its features, see [the website][parseplatfo
 
   Snapshots of the development version are available in [jFrog's `snapshots` repository][snap].
 
-- **Option 2:** Compiling for yourself
+- **Option 2:** Compiling for yourself into JAR/AAR file
 
-  If you want to manually compile the SDK, begin by cloning the repository locally or retrieving the source code for a particular [release](releases). Open the project in Android Studio and run the following commands:
+  If you want to manually compile the SDK, begin by cloning the repository locally or retrieving the source code for a particular [release](releases). Open the project in Android Studio and run the following commands in the Terminal of Android Studio:
   
   ```
   ./gradlew clean jarRelease
   ```
-  Outputs can be found in `Parse/build/libs/`
+  Output file can be found in `Parse/build/outputs/` with extension .aar
   
-  If you want to manually compile the SDK, clone it locally, and run the following commands in the root directory of the repository:
-
-      # To pull in extra dependencies (Bolts and OCMock)
-      git submodule update --init --recursive
-
-      # To install all the gems
-      bundle install
-
-      # Build & Package the Frameworks
-      rake package:frameworks
-
-    Compiled frameworks will be in 2 archives: `Parse-iOS.zip` and `Parse-OSX.zip` inside the `build/release` folder, and you can link them as you'd please.
+  You can link to your project to your AAR file as you please.
     
  ### Setup
 - **Option 1:** Setup in the Manifest
@@ -108,25 +97,8 @@ For more information about Parse and its features, see [the website][parseplatfo
  </application>
  ```
 
-## Download
-Add the dependency in Gradle:
-
-```groovy
-dependencies {
-  compile 'com.parse:parse-android:1.15.8'
-}
-```
-
-Snapshots of the development version are available in [jFrog's `snapshots` repository][snap].
-
 ## Usage
 Everything can done through the supplied gradle wrapper:
-
-### Compile a JAR
-```
-./gradlew clean jarRelease
-```
-Outputs can be found in `Parse/build/libs/`
 
 ### Run the Tests
 ```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,50 @@
 
 [![Join Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/ParsePlatform/Chat)
 
-
 A library that gives you access to the powerful Parse cloud platform from your Android app.
-For more information about Parse and its features, see [the website][parseplatform.org] and [getting started][guide].
+For more information about Parse and its features, see [the website][parseplatform.org], [blog][blog] and [getting started][guide].
+
+
+
+
+## Getting Started
+### Installation
+- **Gradle**
+
+  Add the dependency in Gradle:
+
+  ```groovy
+  dependencies {
+    compile 'com.parse:parse-android:1.15.8'
+  }
+  ```
+
+  Snapshots of the development version are available in [jFrog's `snapshots` repository][snap].
+
+- **Compiling for yourself**
+
+  If you want to manually compile the SDK, begin by cloning the repository locally or retrieving the source code for a particular [release](releases). Open the project in Android Studio and run the following commands:
+  
+  ```
+  ./gradlew clean jarRelease
+  ```
+  Outputs can be found in `Parse/build/libs/`
+  
+  If you want to manually compile the SDK, clone it locally, and run the following commands in the root directory of the repository:
+
+      # To pull in extra dependencies (Bolts and OCMock)
+      git submodule update --init --recursive
+
+      # To install all the gems
+      bundle install
+
+      # Build & Package the Frameworks
+      rake package:frameworks
+
+    Compiled frameworks will be in 2 archives: `Parse-iOS.zip` and `Parse-OSX.zip` inside the `build/release` folder, and you can link them as you'd please.
+    
+    
+    
 
 ## Download
 Add the dependency in Gradle:
@@ -43,7 +84,7 @@ Results can be found in `Parse/build/reports/`
 Results can be found in `Parse/build/reports/`
 
 ## How Do I Contribute?
-We want to make contributing to this project as easy and transparent as possible. Please refer to the [Contribution Guidelines](CONTRIBUTING.md).
+We want to make contributing to this project as easy and transparent as possible. Please refer to the [Contribution Guidelines](contributing).
 
 ## Other Parse Projects
 
@@ -65,6 +106,7 @@ We want to make contributing to this project as easy and transparent as possible
 As of April 5, 2017, Parse, LLC has transferred this code to the parse-community organization, and will no longer be contributing to or distributing this code.
 
  [parseplatform.org]: http://parseplatform.org/
+ [blog]: http://blog.parse.com/
  [guide]: http://docs.parseplatform.org/android/guide/
 
  [latest]: https://search.maven.org/remote_content?g=com.parse&a=parse-android&v=LATEST
@@ -84,3 +126,6 @@ As of April 5, 2017, Parse, LLC has transferred this code to the parse-community
 
  [license-svg]: https://img.shields.io/badge/license-BSD-lightgrey.svg
  [license-link]: https://github.com/parse-community/Parse-SDK-Android/blob/master/LICENSE
+
+ [releases]: https://github.com/parse-community/Parse-SDK-Android/releases
+ [contributing]: https://github.com/parse-community/Parse-SDK-Android/blob/master/CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information about Parse and its features, see [the website][parseplatfo
 
   Snapshots of the development version are available in [jFrog's `snapshots` repository][snap].
 
-- **Option 2:** Compiling for yourself into JAR/AAR file
+- **Option 2:** Compiling for yourself into AAR file
 
   If you want to manually compile the SDK, begin by cloning the repository locally or retrieving the source code for a particular [release][releases]. Open the project in Android Studio and run the following commands in the Terminal of Android Studio:
   


### PR DESCRIPTION
Include details of how to install SDK into Android project using Gradle as well as compiling an AAR file to manually include into Gradle.

Add information from "Getting Started' section in docs:
http://docs.parseplatform.org/android/guide/#getting-started

This contains information on how to initialize Parse using the Manifest or custom `Application` class.

I included an additional step to the README which I believe is missing from the Getting Started docs. It explains that you must remember to reference the custom `Application` class in `AndroidManifest.xml`. See parse-community/docs#446

Fixes issue #705