### PR TITLE
Add Notification Channels configuration for Android O

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ android:
     - tools
     - platform-tools
     - build-tools-25.0.3
-    - android-25
-    - doc-25
+    - android-26
+    - doc-26
 
 before_install:
     - pip install --user codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.3
+    - build-tools-26.0.1
     - android-26
     - doc-26
 

--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile 'com.parse.bolts:bolts-tasks:1.4.0'
     compile "com.squareup.okhttp3:okhttp:$okhttpVersion"
 
-    testCompile 'org.robolectric:robolectric:3.4.2'
+    testCompile 'org.robolectric:robolectric:3.3.2'
     testCompile 'org.skyscreamer:jsonassert:1.5.0'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile "com.squareup.okhttp3:mockwebserver:$okhttpVersion"

--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -59,11 +59,7 @@ dependencies {
     compile 'com.parse.bolts:bolts-tasks:1.4.0'
     compile "com.squareup.okhttp3:okhttp:$okhttpVersion"
 
-    //Be aware, tests fail on 3.3.2 Wait to update until
-    //java.lang.NoClassDefFoundError: android/content/pm/VersionedPackage
-    //issue is fixed in Robolectric
-    //https://github.com/robolectric/robolectric/issues/2562
-    testCompile 'org.robolectric:robolectric:3.3'
+    testCompile 'org.robolectric:robolectric:3.4.2'
     testCompile 'org.skyscreamer:jsonassert:1.5.0'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile "com.squareup.okhttp3:mockwebserver:$okhttpVersion"

--- a/Parse/src/main/java/com/parse/NotificationCompat.java
+++ b/Parse/src/main/java/com/parse/NotificationCompat.java
@@ -97,7 +97,7 @@ import android.widget.RemoteViews;
         }
       }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        postJellyBeanBuilder.setChannelId(b.mNotificationChannel.getId());
+        postJellyBeanBuilder.setChannelId(b.mNotificationChannelId);
       }
       return postJellyBeanBuilder.build();
     }
@@ -128,7 +128,7 @@ import android.widget.RemoteViews;
     Bitmap mLargeIcon;
     int mPriority;
     Style mStyle;
-    NotificationChannel mNotificationChannel;
+    String mNotificationChannelId;
 
     Notification mNotification = new Notification();
 
@@ -196,8 +196,8 @@ import android.widget.RemoteViews;
     /**
      * Set the notification channel of the notification, in a standard notification.
      */
-    public Builder setNotificationChannel(NotificationChannel channel) {
-      mNotificationChannel = channel;
+    public Builder setNotificationChannel(String notificationChannelId) {
+      mNotificationChannelId = notificationChannelId;
       return this;
     }
 

--- a/Parse/src/main/java/com/parse/NotificationCompat.java
+++ b/Parse/src/main/java/com/parse/NotificationCompat.java
@@ -57,7 +57,7 @@ import android.widget.RemoteViews;
     @Override
     public Notification build(Builder builder) {
       Notification result = builder.mNotification;
-      NotificationCompat.Builder newBuilder = new NotificationCompat.Builder(builder.mContext);
+      NotificationCompat.Builder newBuilder = new NotificationCompat.Builder(builder.mContext, builder.mChannelId);
       newBuilder.setContentTitle(builder.mContentTitle);
       newBuilder.setContentText(builder.mContentText);
       newBuilder.setContentIntent(builder.mContentIntent);
@@ -95,6 +95,9 @@ import android.widget.RemoteViews;
           }
         }
       }
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        postJellyBeanBuilder.setChannelId(b.mChannelId);
+      }
       return postJellyBeanBuilder.build();
     }
   }
@@ -117,6 +120,7 @@ import android.widget.RemoteViews;
     private static final int MAX_CHARSEQUENCE_LENGTH = 5 * 1024;
 
     Context mContext;
+    String mChannelId;
 
     CharSequence mContentTitle;
     CharSequence mContentText;
@@ -138,8 +142,9 @@ import android.widget.RemoteViews;
      *      RemoteViews. The Context will not be held past the lifetime of this
      *      Builder object.
      */
-    public Builder(Context context) {
+    public Builder(Context context, String channelId) {
       mContext = context;
+      mChannelId = channelId;
 
       // Set defaults to match the defaults of a Notification
       mNotification.when = System.currentTimeMillis();

--- a/Parse/src/main/java/com/parse/NotificationCompat.java
+++ b/Parse/src/main/java/com/parse/NotificationCompat.java
@@ -18,6 +18,7 @@ package com.parse;
 
 import android.annotation.TargetApi;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -57,7 +58,7 @@ import android.widget.RemoteViews;
     @Override
     public Notification build(Builder builder) {
       Notification result = builder.mNotification;
-      NotificationCompat.Builder newBuilder = new NotificationCompat.Builder(builder.mContext, builder.mChannelId);
+      NotificationCompat.Builder newBuilder = new NotificationCompat.Builder(builder.mContext);
       newBuilder.setContentTitle(builder.mContentTitle);
       newBuilder.setContentText(builder.mContentText);
       newBuilder.setContentIntent(builder.mContentIntent);
@@ -96,7 +97,7 @@ import android.widget.RemoteViews;
         }
       }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        postJellyBeanBuilder.setChannelId(b.mChannelId);
+        postJellyBeanBuilder.setChannelId(b.mNotificationChannel.getId());
       }
       return postJellyBeanBuilder.build();
     }
@@ -120,7 +121,6 @@ import android.widget.RemoteViews;
     private static final int MAX_CHARSEQUENCE_LENGTH = 5 * 1024;
 
     Context mContext;
-    String mChannelId;
 
     CharSequence mContentTitle;
     CharSequence mContentText;
@@ -128,6 +128,7 @@ import android.widget.RemoteViews;
     Bitmap mLargeIcon;
     int mPriority;
     Style mStyle;
+    NotificationChannel mNotificationChannel;
 
     Notification mNotification = new Notification();
 
@@ -142,9 +143,8 @@ import android.widget.RemoteViews;
      *      RemoteViews. The Context will not be held past the lifetime of this
      *      Builder object.
      */
-    public Builder(Context context, String channelId) {
+    public Builder(Context context) {
       mContext = context;
-      mChannelId = channelId;
 
       // Set defaults to match the defaults of a Notification
       mNotification.when = System.currentTimeMillis();
@@ -190,6 +190,14 @@ import android.widget.RemoteViews;
      */
     public Builder setContentTitle(CharSequence title) {
       mContentTitle = limitCharSequenceLength(title);
+      return this;
+    }
+
+    /**
+     * Set the notification channel of the notification, in a standard notification.
+     */
+    public Builder setNotificationChannel(NotificationChannel channel) {
+      mNotificationChannel = channel;
       return this;
     }
 

--- a/Parse/src/main/java/com/parse/ParseNotificationManager.java
+++ b/Parse/src/main/java/com/parse/ParseNotificationManager.java
@@ -50,7 +50,7 @@ import android.util.SparseIntArray;
     return notificationCount.get();
   }
   
-  public void showNotification(Context context, Notification notification, NotificationChannel notificationChannel) {
+  public void showNotification(Context context, Notification notification) {
     if (context != null && notification != null) {
       notificationCount.incrementAndGet();
       
@@ -61,11 +61,6 @@ import android.util.SparseIntArray;
         
         // Pick an id that probably won't overlap anything
         int notificationId = (int)System.currentTimeMillis();
-
-        // Android doesn't recreate a new channel if the properties of the channel hasn't changed
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-          nm.createNotificationChannel(notificationChannel);
-        }
 
         try {
           nm.notify(notificationId, notification);

--- a/Parse/src/main/java/com/parse/ParseNotificationManager.java
+++ b/Parse/src/main/java/com/parse/ParseNotificationManager.java
@@ -62,6 +62,7 @@ import android.util.SparseIntArray;
         // Pick an id that probably won't overlap anything
         int notificationId = (int)System.currentTimeMillis();
 
+        // Android doesn't recreate a new channel if the properties of the channel hasn't changed
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
           nm.createNotificationChannel(notificationChannel);
         }

--- a/Parse/src/main/java/com/parse/ParseNotificationManager.java
+++ b/Parse/src/main/java/com/parse/ParseNotificationManager.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import android.app.Activity;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.ComponentName;
@@ -20,6 +21,7 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.content.res.Resources.NotFoundException;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.SparseIntArray;
 
@@ -48,7 +50,7 @@ import android.util.SparseIntArray;
     return notificationCount.get();
   }
   
-  public void showNotification(Context context, Notification notification) {
+  public void showNotification(Context context, Notification notification, NotificationChannel notificationChannel) {
     if (context != null && notification != null) {
       notificationCount.incrementAndGet();
       
@@ -59,6 +61,10 @@ import android.util.SparseIntArray;
         
         // Pick an id that probably won't overlap anything
         int notificationId = (int)System.currentTimeMillis();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          nm.createNotificationChannel(notificationChannel);
+        }
 
         try {
           nm.notify(notificationId, notification);

--- a/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
+++ b/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
@@ -276,12 +276,22 @@ public class ParsePushBroadcastReceiver extends BroadcastReceiver {
    */
   @TargetApi(Build.VERSION_CODES.O)
   protected NotificationChannel getNotificationChannel(Context context, Intent intent) {
-    NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-    NotificationChannel notificationChannel = new NotificationChannel("parse_push", "Push notifications", NotificationManager.IMPORTANCE_DEFAULT);
+    return new NotificationChannel("parse_push", "Push notifications", NotificationManager.IMPORTANCE_DEFAULT);
+  }
 
-    // Android doesn't create a new channel if the properties of the channel hasn't changed
+  /**
+   * Creates the notification channel with the NotificationManager. Channel is not recreated
+   * if the channel properties are unchanged.
+   *
+   * @param context
+   *      The {@code Context} in which the receiver is running.
+   * @param notificationChannel
+   *      The {@code NotificationChannel} to be created.
+   */
+  @TargetApi(Build.VERSION_CODES.O)
+  protected void createNotificationChannel(Context context, NotificationChannel notificationChannel) {
+    NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
     nm.createNotificationChannel(notificationChannel);
-    return notificationChannel;
   }
 
   /**
@@ -405,6 +415,7 @@ public class ParsePushBroadcastReceiver extends BroadcastReceiver {
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       NotificationChannel notificationChannel = getNotificationChannel(context, intent);
+      createNotificationChannel(context, notificationChannel);
       parseBuilder.setNotificationChannel(notificationChannel);
     }
 

--- a/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
+++ b/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
@@ -94,6 +94,9 @@ public class ParsePushBroadcastReceiver extends BroadcastReceiver {
   /** The name of the meta-data field used to override the icon used in Notifications. */
   public static final String PROPERTY_PUSH_ICON = "com.parse.push.notification_icon";
 
+  /** The name of the meta-data field used to override the channel id used in Notifications. */
+  public static final String PROPERTY_PUSH_CHANNEL = "com.parse.push.notification_channel";
+
   protected static final int SMALL_NOTIFICATION_MAX_CHARACTER_LIMIT = 38;
 
   /**
@@ -261,6 +264,27 @@ public class ParsePushBroadcastReceiver extends BroadcastReceiver {
   }
 
   /**
+   * Retrieves the channel id to be used in a {@link Notification}. The default implementation uses
+   * the channelId specified by {@code com.parse.push.notification_channel} {@code meta-data} in your
+   * {@code AndroidManifest.xml} with a fallback to "parse_push".
+   *
+   * @param context
+   *      The {@code Context} in which the receiver is running.
+   * @param intent
+   *      An {@code Intent} containing the channel and data of the current push notification.
+   * @return
+   *      The string of the channel name
+   */
+  protected String getChannelId(Context context, Intent intent) {
+    Bundle metaData = ManifestInfo.getApplicationMetadata(context);
+    String channelId = null;
+    if (metaData != null) {
+      channelId = metaData.getString(PROPERTY_PUSH_CHANNEL);
+    }
+    return channelId == null ? "parse_push" : channelId;
+  }
+
+  /**
    * Retrieves the small icon to be used in a {@link Notification}. The default implementation uses
    * the icon specified by {@code com.parse.push.notification_icon} {@code meta-data} in your
    * {@code AndroidManifest.xml} with a fallback to the launcher icon for this package. To conform
@@ -366,7 +390,7 @@ public class ParsePushBroadcastReceiver extends BroadcastReceiver {
 
     // The purpose of setDefaults(Notification.DEFAULT_ALL) is to inherit notification properties
     // from system defaults
-    NotificationCompat.Builder parseBuilder = new NotificationCompat.Builder(context);
+    NotificationCompat.Builder parseBuilder = new NotificationCompat.Builder(context, this.getChannelId(context, intent));
     parseBuilder.setContentTitle(title)
         .setContentText(alert)
         .setTicker(tickerText)

--- a/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
+++ b/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
@@ -416,7 +416,7 @@ public class ParsePushBroadcastReceiver extends BroadcastReceiver {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       NotificationChannel notificationChannel = getNotificationChannel(context, intent);
       createNotificationChannel(context, notificationChannel);
-      parseBuilder.setNotificationChannel(notificationChannel);
+      parseBuilder.setNotificationChannel(notificationChannel.getId());
     }
 
     if (alert != null

--- a/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
+++ b/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(constants = BuildConfig.class)
+@Config(constants = BuildConfig.class, sdk = TestHelper.ROBOLECTRIC_SDK_VERSION)
 public class ParseClientConfigurationTest {
 
   private final String serverUrl = "http://example.com/parse";

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ allprojects {
 
 ext {
     compileSdkVersion = 26
-    buildToolsVersion = "26.0.1"
+    buildToolsVersion = "25.0.3"
 
     supportLibVersion = '25.3.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,11 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 25
-    buildToolsVersion = "25.0.3"
+    compileSdkVersion = 26
+    buildToolsVersion = "26.0.1"
 
     supportLibVersion = '25.3.1'
 
     minSdkVersion = 9
-    targetSdkVersion = 25
+    targetSdkVersion = 26
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ allprojects {
 
 ext {
     compileSdkVersion = 26
-    buildToolsVersion = "25.0.3"
+    buildToolsVersion = "26.0.1"
 
     supportLibVersion = '25.3.1'
 


### PR DESCRIPTION
 In response to my own issue #711 I tried to add the support myself.

I added the new meta-tag `com.parse.push.notification_channel` which defaults to `"parse_push"`.
If the Android version SDK is 26 or above, the channelId is set to the notification. The project is also compiled against SDK 26 in order to get the notification api.

I have no idea how to test this, so any help or pointers are appreciated.