### PR TITLE
Check for JSONObject.NULL before casting to String [Fixes #209]

### DIFF
--- a/Parse/src/main/java/com/parse/ParseDecoder.java
+++ b/Parse/src/main/java/com/parse/ParseDecoder.java
@@ -71,6 +71,10 @@ import org.json.JSONObject;
       return convertJSONArrayToList((JSONArray) object);
     }
 
+    if (object == JSONObject.NULL) {
+      return null;
+    }
+
     if (!(object instanceof JSONObject)) {
       return object;
     }

--- a/Parse/src/test/java/com/parse/ParseDecoderTest.java
+++ b/Parse/src/test/java/com/parse/ParseDecoderTest.java
@@ -74,6 +74,12 @@ public class ParseDecoderTest extends ResetPluginsParseTest {
   }
 
   @Test
+  public void testNull() {
+    Object object = ParseDecoder.get().decode(JSONObject.NULL);
+    assertNull(object);
+  }
+
+  @Test
   public void testParseFieldOperations() throws JSONException {
     JSONObject json = new JSONObject();
     json.put("__op", "Increment");


### PR DESCRIPTION
The same technique is already used in `ParseObject.getString()`, but because this is a ParseObject.State subclass, there is no getString() method. The documentation explicitly states that JSONObject.NULL may be contained in the data.

Before the change, the unit test fails with:
```
com.parse.ParseUserTest > testSessionTokenFromNull FAILED
    java.lang.ClassCastException: org.json.JSONObject$1 cannot be cast to java.lang.String
        at com.parse.ParseUser$State.sessionToken(ParseUser.java:139)
        at com.parse.ParseUser.getSessionToken(ParseUser.java:313)
        at com.parse.ParseUserTest.testSessionTokenFromNull(ParseUserTest.java:137)
```