### PR TITLE
Fix ParseUserCurrentCoder bug

### DIFF
--- a/Parse/src/test/java/com/parse/ParseConfigTest.java
+++ b/Parse/src/test/java/com/parse/ParseConfigTest.java
@@ -48,16 +48,12 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 // For android.os.Looper
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = TestHelper.ROBOLECTRIC_SDK_VERSION)
-public class ParseConfigTest {
+public class ParseConfigTest extends ResetPluginsParseTest {
 
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
+    super.setUp();
     ParseTestUtils.setTestParseUser();
-  }
-
-  @After
-  public void tearDown() {
-    ParseCorePlugins.getInstance().reset();
   }
 
   //region testConstructor

--- a/Parse/src/test/java/com/parse/ParseInstallationTest.java
+++ b/Parse/src/test/java/com/parse/ParseInstallationTest.java
@@ -27,6 +27,7 @@ import java.util.TimeZone;
 import bolts.Task;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -253,8 +254,16 @@ public class ParseInstallationTest extends ResetPluginsParseTest {
     installation.updateBeforeSave();
 
     // Make sure we update timezone
-    String zone = TimeZone.getDefault().getID();
-    assertEquals(zone, installation.getString(KEY_TIME_ZONE));
+    String zone = installation.getString(KEY_TIME_ZONE);
+    String deviceZone = TimeZone.getDefault().getID();
+    if (zone != null) {
+        assertEquals(zone, deviceZone);
+    } else {
+        // If it's not updated it's because it was not acceptable.
+        assertFalse(deviceZone.equals("GMT"));
+        assertFalse(deviceZone.indexOf("/") > 0);
+    }
+
     // Make sure we update version info
     Context context = Parse.getApplicationContext();
     String packageName = context.getPackageName();
@@ -265,9 +274,11 @@ public class ParseInstallationTest extends ResetPluginsParseTest {
     assertEquals(packageName, installation.getString(KEY_APP_IDENTIFIER));
     assertEquals(appName, installation.getString(KEY_APP_NAME));
     assertEquals(appVersion, installation.getString(KEY_APP_VERSION));
+
     // Make sure we update device info
     assertEquals("android", installation.getString(KEY_DEVICE_TYPE));
     assertEquals("installationId", installation.getString(KEY_INSTALLATION_ID));
+
     // Make sure we update the locale identifier
     assertEquals("en-US", installation.getString(KEY_LOCALE_IDENTIFIER));
   }

--- a/Parse/src/test/java/com/parse/ParseUserCurrentCoderTest.java
+++ b/Parse/src/test/java/com/parse/ParseUserCurrentCoderTest.java
@@ -92,9 +92,6 @@ public class ParseUserCurrentCoderTest {
     Map<String, String> twitterAuthData = authData.get("twitter");
     assertEquals("twitterId", twitterAuthData.get("id"));
     assertEquals("twitterAccessToken", twitterAuthData.get("access_token"));
-    // Make sure objectJson does not have sessionToken and authData anymore
-    assertFalse(objectJson.has(KEY_SESSION_TOKEN));
-    assertFalse(objectJson.has(KEY_AUTH_DATA));
   }
 
   @Test

--- a/Parse/src/test/java/com/parse/ParseUserCurrentCoderTest.java
+++ b/Parse/src/test/java/com/parse/ParseUserCurrentCoderTest.java
@@ -111,4 +111,19 @@ public class ParseUserCurrentCoderTest {
     // We always return non-null for authData()
     assertEquals(0, state.authData().size());
   }
+
+  @Test
+  public void testEncodeDecodeWithNullValues() throws Exception {
+    ParseUser.State state = new ParseUser.State.Builder()
+        .sessionToken(null)
+        .authData(null)
+        .build();
+    ParseUserCurrentCoder coder = ParseUserCurrentCoder.get();
+    JSONObject object = coder.encode(state, null, PointerEncoder.get());
+    ParseUser.State.Builder builder =
+            coder.decode(new ParseUser.State.Builder(), object, ParseDecoder.get());
+    state = builder.build();
+    assertNull(state.sessionToken());
+    assertEquals(0, state.authData().size());
+  }
 }


### PR DESCRIPTION
Fixes a bug that would make session token be `JSONObject.NULL` instead of `null`, causing #209 .