### PR TITLE
Update the Javadoc

### DIFF
--- a/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
+++ b/Parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
@@ -68,8 +68,10 @@ import java.util.Random;
  * {@link #onPushOpen(Context, Intent)}, or {@link #onPushDismiss(Context, Intent)}.
  * To make minor changes to the appearance of a notification, override
  * {@link #getSmallIconId(Context, Intent)} or {@link #getLargeIcon(Context, Intent)}. To completely
- * change the Notification generated, override {@link #getNotification(Context, Intent)}. To change
- * the Activity launched when a user opens a Notification, override
+ * change the Notification generated, override {@link #getNotification(Context, Intent)}. To
+ * change the NotificationChannel generated, override {@link #getNotificationChannel(Context, Intent)}. To
+ * change how the NotificationChannel is created, override {@link #createNotificationChannel(Context, NotificationChannel)}.
+ * To change the Activity launched when a user opens a Notification, override
  * {@link #getActivity(Context, Intent)}.
  */
 // Hack note: Javadoc smashes the last two paragraphs together without the <p> tags.


### PR DESCRIPTION
I forgot to add javadoc for the new functions to the class. I tried generating new javadocs for the gh-pages branch, but I don't know if that javadoc includes other libraries because some classes were missing after. I can submit a PR for the javadocs if you want.