### PR TITLE
Remove deprecated getParseDir

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -486,15 +486,6 @@ public class Parse {
     return true;
   }
 
-  /**
-   * @deprecated Please use {@link #getParseCacheDir(String)} or {@link #getParseFilesDir(String)}
-   * instead.
-   */
-  @Deprecated
-  static File getParseDir() {
-    return ParsePlugins.get().getParseDir();
-  }
-
   static File getParseCacheDir() {
     return ParsePlugins.get().getCacheDir();
   }

--- a/Parse/src/main/java/com/parse/ParseCommandCache.java
+++ b/Parse/src/main/java/com/parse/ParseCommandCache.java
@@ -53,7 +53,7 @@ import bolts.TaskCompletionSource;
 
   private static File getCacheDir() {
     // Construct the path to the cache directory.
-    File cacheDir = new File(Parse.getParseDir(), "CommandCache");
+    File cacheDir = new File(Parse.getParseCacheDir(), "CommandCache");
     cacheDir.mkdirs();
 
     return cacheDir;

--- a/Parse/src/main/java/com/parse/ParseCorePlugins.java
+++ b/Parse/src/main/java/com/parse/ParseCorePlugins.java
@@ -127,7 +127,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
   public ParseCurrentUserController getCurrentUserController() {
     if (currentUserController.get() == null) {
-      File file = new File(Parse.getParseDir(), FILENAME_CURRENT_USER);
+      File file = new File(Parse.getParseCacheDir(), FILENAME_CURRENT_USER);
       FileObjectStore<ParseUser> fileStore =
           new FileObjectStore<>(ParseUser.class, file, ParseUserCurrentCoder.get());
       ParseObjectStore<ParseUser> store = Parse.isLocalDatastoreEnabled()
@@ -325,7 +325,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
   public LocalIdManager getLocalIdManager() {
     if (localIdManager.get() == null) {
-      LocalIdManager manager = new LocalIdManager(Parse.getParseDir());
+      LocalIdManager manager = new LocalIdManager(Parse.getParseCacheDir());
       localIdManager.compareAndSet(null, manager);
     }
     return localIdManager.get();


### PR DESCRIPTION
Remove access and replace usages with the non-deprecated method