### PR TITLE
Remove build tools and shorten travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,12 @@
-branches:
-  only:
-    - master
-    - /^\d+\.\d+\.\d+$/ # regex
-
 language: android
-sudo: false
 
 jdk:
   - oraclejdk8
 
-android:
-  components:
-    - tools
-    - platform-tools
-    - build-tools-27.0.0
-    - android-27
-    - doc-27
-
 before_install:
-    - pip install --user codecov
+  - pip install --user codecov
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
 
 script:
   - ./gradlew clean testDebugUnitTest jacocoTestReport

--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -25,7 +25,6 @@ buildscript {
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
@@ -51,7 +50,7 @@ android {
 }
 
 ext {
-    okhttpVersion = '3.9.0'
+    okhttpVersion = '3.9.1'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
@@ -23,9 +23,8 @@ allprojects {
 
 ext {
     compileSdkVersion = 27
-    buildToolsVersion = "27.0.0"
 
-    supportLibVersion = '27.0.1'
+    supportLibVersion = '27.0.2'
 
     minSdkVersion = 14
     targetSdkVersion = 27


### PR DESCRIPTION
This way we don't have to keep updating the travis configuration over and over, the dependencies are determined and downloaded at build time. 