### PR TITLE
Allow setting of max retries

### DIFF
--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'com.jfrog.bintray'
 
 group = 'com.parse'
-version = '1.16.5'
+version = '1.16.6-SNAPSHOT'
 
 ext {
     projDescription = 'A library that gives you access to the powerful Parse cloud platform from your Android app.'

--- a/Parse/src/main/java/com/parse/CacheQueryController.java
+++ b/Parse/src/main/java/com/parse/CacheQueryController.java
@@ -33,8 +33,8 @@ import bolts.Task;
     final String sessionToken = user != null ? user.getSessionToken() : null;
     CommandDelegate<List<T>> callbacks = new CommandDelegate<List<T>>() {
       @Override
-      public Task<List<T>> runOnNetworkAsync(boolean retry) {
-        return networkController.findAsync(state, sessionToken, retry, cancellationToken);
+      public Task<List<T>> runOnNetworkAsync() {
+        return networkController.findAsync(state, sessionToken, cancellationToken);
       }
 
       @Override
@@ -53,8 +53,8 @@ import bolts.Task;
     final String sessionToken = user != null ? user.getSessionToken() : null;
     CommandDelegate<Integer> callbacks = new CommandDelegate<Integer>() {
       @Override
-      public Task<Integer> runOnNetworkAsync(boolean retry) {
-        return networkController.countAsync(state, sessionToken, retry, cancellationToken);
+      public Task<Integer> runOnNetworkAsync() {
+        return networkController.countAsync(state, sessionToken, cancellationToken);
       }
 
       @Override
@@ -124,7 +124,7 @@ import bolts.Task;
     switch (policy) {
       case IGNORE_CACHE:
       case NETWORK_ONLY:
-        return c.runOnNetworkAsync(true);
+        return c.runOnNetworkAsync();
       case CACHE_ONLY:
         return c.runFromCacheAsync();
       case CACHE_ELSE_NETWORK:
@@ -133,13 +133,13 @@ import bolts.Task;
           @Override
           public Task<TResult> then(Task<TResult> task) throws Exception {
             if (task.getError() instanceof ParseException) {
-              return c.runOnNetworkAsync(true);
+              return c.runOnNetworkAsync();
             }
             return task;
           }
         });
       case NETWORK_ELSE_CACHE:
-        return c.runOnNetworkAsync(false).continueWithTask(new Continuation<TResult, Task<TResult>>() {
+        return c.runOnNetworkAsync().continueWithTask(new Continuation<TResult, Task<TResult>>() {
           @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
           @Override
           public Task<TResult> then(Task<TResult> task) throws Exception {
@@ -167,7 +167,7 @@ import bolts.Task;
    */
   private interface CommandDelegate<T> {
     // Fetches data from the network.
-    Task<T> runOnNetworkAsync(boolean retry);
+    Task<T> runOnNetworkAsync();
 
     // Fetches data from the cache.
     Task<T> runFromCacheAsync();

--- a/Parse/src/main/java/com/parse/NetworkObjectController.java
+++ b/Parse/src/main/java/com/parse/NetworkObjectController.java
@@ -33,7 +33,6 @@ import bolts.Task;
         state.objectId(),
         state.className(),
         sessionToken);
-    command.enableRetrying();
 
     return command.executeAsync(client).onSuccess(new Continuation<JSONObject, ParseObject.State>() {
       @Override
@@ -64,7 +63,6 @@ import bolts.Task;
         state,
         objectJSON,
         sessionToken);
-    command.enableRetrying();
     return command.executeAsync(client).onSuccess(new Continuation<JSONObject, ParseObject.State>() {
       @Override
       public ParseObject.State then(Task<JSONObject> task) throws Exception {
@@ -124,7 +122,6 @@ import bolts.Task;
   public Task<Void> deleteAsync(ParseObject.State state, String sessionToken) {
     ParseRESTObjectCommand command = ParseRESTObjectCommand.deleteObjectCommand(
         state, sessionToken);
-    command.enableRetrying();
 
     return command.executeAsync(client).makeVoid();
   }
@@ -139,7 +136,6 @@ import bolts.Task;
       ParseObject.State state = states.get(i);
       ParseRESTObjectCommand command = ParseRESTObjectCommand.deleteObjectCommand(
           state, sessionToken);
-      command.enableRetrying();
       commands.add(command);
     }
 

--- a/Parse/src/main/java/com/parse/NetworkQueryController.java
+++ b/Parse/src/main/java/com/parse/NetworkQueryController.java
@@ -32,14 +32,14 @@ import bolts.Task;
   public <T extends ParseObject> Task<List<T>> findAsync(
       ParseQuery.State<T> state, ParseUser user, Task<Void> cancellationToken) {
     String sessionToken = user != null ? user.getSessionToken() : null;
-    return findAsync(state, sessionToken, true, cancellationToken);
+    return findAsync(state, sessionToken, cancellationToken);
   }
 
   @Override
   public <T extends ParseObject> Task<Integer> countAsync(
       ParseQuery.State<T> state, ParseUser user, Task<Void> cancellationToken) {
     String sessionToken = user != null ? user.getSessionToken() : null;
-    return countAsync(state, sessionToken, true, cancellationToken);
+    return countAsync(state, sessionToken, cancellationToken);
   }
 
   /**
@@ -50,14 +50,10 @@ import bolts.Task;
   /* package */ <T extends ParseObject> Task<List<T>> findAsync(
       final ParseQuery.State<T> state,
       String sessionToken,
-      boolean shouldRetry,
       Task<Void> ct) {
     final long queryStart = System.nanoTime();
 
     final ParseRESTCommand command = ParseRESTQueryCommand.findCommand(state, sessionToken);
-    if (shouldRetry) {
-      command.enableRetrying();
-    }
 
     final long querySent = System.nanoTime();
     return command.executeAsync(restClient, ct).onSuccess(new Continuation<JSONObject, List<T>>() {
@@ -94,12 +90,8 @@ import bolts.Task;
   /* package */ <T extends ParseObject> Task<Integer> countAsync(
       final ParseQuery.State<T> state,
       String sessionToken,
-      boolean shouldRetry,
       Task<Void> ct) {
     final ParseRESTCommand command = ParseRESTQueryCommand.countCommand(state, sessionToken);
-    if (shouldRetry) {
-      command.enableRetrying();
-    }
 
     return command.executeAsync(restClient, ct).onSuccessTask(new Continuation<JSONObject, Task<JSONObject>>() {
       @Override

--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -36,6 +36,8 @@ import okhttp3.OkHttpClient;
 public class Parse {
   private static final String TAG = "com.parse.Parse";
 
+  private static final int DEFAULT_MAX_RETRIES = 4;
+
   /**
    * Represents an opaque configuration for the {@code Parse} SDK configuration.
    */
@@ -50,6 +52,7 @@ public class Parse {
       private String server;
       private boolean localDataStoreEnabled;
       private OkHttpClient.Builder clientBuilder;
+      private int maxRetries = DEFAULT_MAX_RETRIES;
 
       /**
        * Initialize a bulider with a given context.
@@ -180,6 +183,18 @@ public class Parse {
       }
 
       /**
+       * Set the max number of times to retry Parse operations before deeming them a failure
+       * <p>
+       *
+       * @param maxRetries The maximum number of times to retry. <=0 to never retry commands
+       * @return The same builder, for easy chaining.
+       */
+      public Builder maxRetries(int maxRetries) {
+        this.maxRetries = maxRetries;
+        return this;
+      }
+
+      /**
        * Construct this builder into a concrete {@code Configuration} instance.
        *
        * @return A constructed {@code Configuration} object.
@@ -195,6 +210,7 @@ public class Parse {
     final String server;
     final boolean localDataStoreEnabled;
     final OkHttpClient.Builder clientBuilder;
+    final int maxRetries;
 
 
     private Configuration(Builder builder) {
@@ -204,6 +220,7 @@ public class Parse {
       this.server = builder.server;
       this.localDataStoreEnabled = builder.localDataStoreEnabled;
       this.clientBuilder = builder.clientBuilder;
+      this.maxRetries = builder.maxRetries;
     }
   }
 
@@ -376,11 +393,6 @@ public class Parse {
     } catch (MalformedURLException ex) {
       throw new RuntimeException(ex);
     }
-
-    Context applicationContext = configuration.context.getApplicationContext();
-
-    ParseHttpClient.setKeepAlive(true);
-    ParseHttpClient.setMaxConnections(20);
 
     ParseObject.registerParseSubclasses();
 

--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -36,7 +36,7 @@ import okhttp3.OkHttpClient;
 public class Parse {
   private static final String TAG = "com.parse.Parse";
 
-  private static final int DEFAULT_MAX_RETRIES = 4;
+  private static final int DEFAULT_MAX_RETRIES = ParseRequest.DEFAULT_MAX_RETRIES;
 
   /**
    * Represents an opaque configuration for the {@code Parse} SDK configuration.

--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -369,7 +369,7 @@ public class Parse {
     // isLocalDataStoreEnabled() to perform additional behavior.
     isLocalDatastoreEnabled = configuration.localDataStoreEnabled;
 
-    ParsePlugins.Android.initialize(configuration.context, configuration);
+    ParsePlugins.initialize(configuration.context, configuration);
 
     try {
       ParseRESTCommand.server = new URL(configuration.server);
@@ -459,7 +459,7 @@ public class Parse {
 
   static Context getApplicationContext() {
     checkContext();
-    return ParsePlugins.Android.get().applicationContext();
+    return ParsePlugins.get().applicationContext();
   }
 
   /**
@@ -580,7 +580,7 @@ public class Parse {
    * processing any commands already stored in the on-disk queue.
    */
   static ParseEventuallyQueue getEventuallyQueue() {
-    Context context = ParsePlugins.Android.get().applicationContext();
+    Context context = ParsePlugins.get().applicationContext();
     return getEventuallyQueue(context);
   }
 
@@ -621,7 +621,7 @@ public class Parse {
   }
 
   static void checkContext() {
-    if (ParsePlugins.Android.get().applicationContext() == null) {
+    if (ParsePlugins.get().applicationContext() == null) {
       throw new RuntimeException("applicationContext is null. "
               + "You must call Parse.initialize(Context)"
               + " before using the Parse library.");

--- a/Parse/src/main/java/com/parse/ParseConfigController.java
+++ b/Parse/src/main/java/com/parse/ParseConfigController.java
@@ -29,7 +29,6 @@ import bolts.Task;
 
   public Task<ParseConfig> getAsync(String sessionToken) {
     final ParseRESTCommand command = ParseRESTConfigCommand.fetchConfigCommand(sessionToken);
-    command.enableRetrying();
     return command.executeAsync(restClient).onSuccessTask(new Continuation<JSONObject, Task<ParseConfig>>() {
       @Override
       public Task<ParseConfig> then(Task<JSONObject> task) throws Exception {

--- a/Parse/src/main/java/com/parse/ParseFileController.java
+++ b/Parse/src/main/java/com/parse/ParseFileController.java
@@ -98,7 +98,6 @@ import bolts.Task;
         .contentType(state.mimeType())
         .sessionToken(sessionToken)
         .build();
-    command.enableRetrying();
 
     return command.executeAsync(
         restClient,
@@ -145,7 +144,6 @@ import bolts.Task;
         .contentType(state.mimeType())
         .sessionToken(sessionToken)
         .build();
-    command.enableRetrying();
 
     return command.executeAsync(
         restClient,

--- a/Parse/src/main/java/com/parse/ParseHttpClient.java
+++ b/Parse/src/main/java/com/parse/ParseHttpClient.java
@@ -38,20 +38,6 @@ class ParseHttpClient {
     return new ParseHttpClient(builder);
   }
 
-  private static final String MAX_CONNECTIONS_PROPERTY_NAME = "http.maxConnections";
-  private static final String KEEP_ALIVE_PROPERTY_NAME = "http.keepAlive";
-
-  static void setMaxConnections(int maxConnections) {
-    if (maxConnections <= 0) {
-      throw new IllegalArgumentException("Max connections should be large than 0");
-    }
-    System.setProperty(MAX_CONNECTIONS_PROPERTY_NAME, String.valueOf(maxConnections));
-  }
-
-  static void setKeepAlive(boolean isKeepAlive) {
-    System.setProperty(KEEP_ALIVE_PROPERTY_NAME, String.valueOf(isKeepAlive));
-  }
-
   private OkHttpClient okHttpClient;
   private boolean hasExecuted;
 

--- a/Parse/src/main/java/com/parse/ParseObject.java
+++ b/Parse/src/main/java/com/parse/ParseObject.java
@@ -1344,7 +1344,6 @@ public class ParseObject implements Parcelable {
           state,
           objectJSON,
           sessionToken);
-    command.enableRetrying();
     return command;
   }
 
@@ -1880,7 +1879,6 @@ public class ParseObject implements Parcelable {
       // See [1]
       command = ParseRESTObjectCommand.deleteObjectCommand(
           getState(), sessionToken);
-      command.enableRetrying();
       command.setLocalId(localId);
 
       runEventuallyTask = Parse.getEventuallyQueue().enqueueEventuallyAsync(command, ParseObject.this);

--- a/Parse/src/main/java/com/parse/ParsePlugins.java
+++ b/Parse/src/main/java/com/parse/ParsePlugins.java
@@ -82,6 +82,10 @@ class ParsePlugins {
         return configuration.clientKey;
     }
 
+    Parse.Configuration configuration() {
+        return configuration;
+    }
+
     Context applicationContext() {
         return applicationContext;
     }

--- a/Parse/src/main/java/com/parse/ParsePlugins.java
+++ b/Parse/src/main/java/com/parse/ParsePlugins.java
@@ -28,10 +28,8 @@ class ParsePlugins {
     private static final Object LOCK = new Object();
     private static ParsePlugins instance;
 
-    // TODO(grantland): Move towards a Config/Builder parameter pattern to allow other configurations
-    // such as path (disabled for Android), etc.
-    static void initialize(Parse.Configuration configuration) {
-        ParsePlugins.set(new ParsePlugins(configuration));
+    static void initialize(Context context, Parse.Configuration configuration) {
+        ParsePlugins.set(new ParsePlugins(context, configuration));
     }
 
     static void set(ParsePlugins plugins) {
@@ -58,6 +56,8 @@ class ParsePlugins {
     final Object lock = new Object();
     private final Parse.Configuration configuration;
 
+    private Context applicationContext;
+
     private InstallationId installationId;
 
     File parseDir;
@@ -67,7 +67,10 @@ class ParsePlugins {
     ParseHttpClient restClient;
     ParseHttpClient fileClient;
 
-    private ParsePlugins(Parse.Configuration configuration) {
+    private ParsePlugins(Context context, Parse.Configuration configuration) {
+        if (context != null) {
+            applicationContext = context.getApplicationContext();
+        }
         this.configuration = configuration;
     }
 
@@ -77,6 +80,10 @@ class ParsePlugins {
 
     String clientKey() {
         return configuration.clientKey;
+    }
+
+    Context applicationContext() {
+        return applicationContext;
     }
 
     ParseHttpClient fileClient() {
@@ -129,9 +136,20 @@ class ParsePlugins {
         }
     }
 
-    // TODO(grantland): Pass through some system values.
     String userAgent() {
-        return "Parse Java SDK";
+        String packageVersion = "unknown";
+        try {
+            String packageName = applicationContext.getPackageName();
+            int versionCode = applicationContext
+                    .getPackageManager()
+                    .getPackageInfo(packageName, 0)
+                    .versionCode;
+            packageVersion = packageName + "/" + versionCode;
+        } catch (PackageManager.NameNotFoundException e) {
+            // Should never happen.
+        }
+        return "Parse Android SDK " + ParseObject.VERSION_NAME + " (" + packageVersion +
+                ") API Level " + Build.VERSION.SDK_INT;
     }
 
     InstallationId installationId() {
@@ -146,84 +164,29 @@ class ParsePlugins {
 
     @Deprecated
     File getParseDir() {
-        throw new IllegalStateException("Stub");
+        synchronized (lock) {
+            if (parseDir == null) {
+                parseDir = applicationContext.getDir("Parse", Context.MODE_PRIVATE);
+            }
+            return createFileDir(parseDir);
+        }
     }
 
     File getCacheDir() {
-        throw new IllegalStateException("Stub");
+        synchronized (lock) {
+            if (cacheDir == null) {
+                cacheDir = new File(applicationContext.getCacheDir(), "com.parse");
+            }
+            return createFileDir(cacheDir);
+        }
     }
 
     File getFilesDir() {
-        throw new IllegalStateException("Stub");
-    }
-
-    static class Android extends ParsePlugins {
-
-        static void initialize(Context context, Parse.Configuration configuration) {
-            ParsePlugins.set(new Android(context, configuration));
-        }
-
-        static ParsePlugins.Android get() {
-            return (ParsePlugins.Android) ParsePlugins.get();
-        }
-
-        private final Context applicationContext;
-
-        private Android(Context context, Parse.Configuration configuration) {
-            super(configuration);
-            applicationContext = context.getApplicationContext();
-        }
-
-        Context applicationContext() {
-            return applicationContext;
-        }
-
-        @Override
-        String userAgent() {
-            String packageVersion = "unknown";
-            try {
-                String packageName = applicationContext.getPackageName();
-                int versionCode = applicationContext
-                        .getPackageManager()
-                        .getPackageInfo(packageName, 0)
-                        .versionCode;
-                packageVersion = packageName + "/" + versionCode;
-            } catch (PackageManager.NameNotFoundException e) {
-                // Should never happen.
+        synchronized (lock) {
+            if (filesDir == null) {
+                filesDir = new File(applicationContext.getFilesDir(), "com.parse");
             }
-            return "Parse Android SDK " + ParseObject.VERSION_NAME + " (" + packageVersion +
-                    ") API Level " + Build.VERSION.SDK_INT;
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        File getParseDir() {
-            synchronized (lock) {
-                if (parseDir == null) {
-                    parseDir = applicationContext.getDir("Parse", Context.MODE_PRIVATE);
-                }
-                return createFileDir(parseDir);
-            }
-        }
-
-        @Override
-        File getCacheDir() {
-            synchronized (lock) {
-                if (cacheDir == null) {
-                    cacheDir = new File(applicationContext.getCacheDir(), "com.parse");
-                }
-                return createFileDir(cacheDir);
-            }
-        }
-
-        @Override
-        File getFilesDir() {
-            synchronized (lock) {
-                if (filesDir == null) {
-                    filesDir = new File(applicationContext.getFilesDir(), "com.parse");
-                }
-                return createFileDir(filesDir);
-            }
+            return createFileDir(filesDir);
         }
     }
 

--- a/Parse/src/main/java/com/parse/ParseRESTCommand.java
+++ b/Parse/src/main/java/com/parse/ParseRESTCommand.java
@@ -186,11 +186,6 @@ import bolts.Task;
     return new ParseRESTCommand(httpPath, httpMethod, jsonParameters, localId, sessionToken);
   }
 
-  // TODO(grantland): But we don't disable retries by default...
-  /* package */ void enableRetrying() {
-    setMaxRetries(DEFAULT_MAX_RETRIES);
-  }
-
   private static String createUrl(String httpPath) {
     // We send all parameters for GET/HEAD/DELETE requests in a post body,
     // so no need to worry about query parameters here.

--- a/Parse/src/main/java/com/parse/ParseRequest.java
+++ b/Parse/src/main/java/com/parse/ParseRequest.java
@@ -76,7 +76,14 @@ abstract class ParseRequest<Response> {
     return defaultInitialRetryDelay;
   }
 
-  private int maxRetries = DEFAULT_MAX_RETRIES;
+  private static int maxRetries() {
+    //typically happens just within tests
+    if (ParsePlugins.get() == null) {
+      return DEFAULT_MAX_RETRIES;
+    } else {
+      return ParsePlugins.get().configuration().maxRetries;
+    }
+  }
 
   /* package */ ParseHttpRequest.Method method;
   /* package */ String url;
@@ -221,7 +228,7 @@ abstract class ParseRequest<Response> {
             return task;
           }
 
-          if (attemptsMade < maxRetries) {
+          if (attemptsMade < maxRetries()) {
             PLog.i("com.parse.ParseRequest", "Request failed. Waiting " + delay
                 + " milliseconds before attempt #" + (attemptsMade + 1));
 

--- a/Parse/src/main/java/com/parse/ParseRequest.java
+++ b/Parse/src/main/java/com/parse/ParseRequest.java
@@ -90,10 +90,6 @@ abstract class ParseRequest<Response> {
     this.url = url;
   }
 
-  public void setMaxRetries(int max) {
-    maxRetries = max;
-  }
-
   protected ParseHttpBody newBody(ProgressCallback uploadProgressCallback) {
     // do nothing
     return null;

--- a/Parse/src/main/java/com/parse/ParseRequest.java
+++ b/Parse/src/main/java/com/parse/ParseRequest.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.os.Build;
+import android.support.annotation.NonNull;
 
 import com.parse.http.ParseHttpBody;
 import com.parse.http.ParseHttpRequest;
@@ -31,12 +31,12 @@ import bolts.TaskCompletionSource;
  * ParseRequest takes an arbitrary HttpUriRequest and retries it a number of times with
  * exponential backoff.
  */
-/** package */ abstract class ParseRequest<Response> {
+abstract class ParseRequest<Response> {
 
   private static final ThreadFactory sThreadFactory = new ThreadFactory() {
     private final AtomicInteger mCount = new AtomicInteger(1);
 
-    public Thread newThread(Runnable r) {
+    public Thread newThread(@NonNull Runnable r) {
       return new Thread(r, "ParseRequest.NETWORK_EXECUTOR-thread-" + mCount.getAndIncrement());
     }
   };
@@ -56,9 +56,7 @@ import bolts.TaskCompletionSource;
       ThreadFactory threadFactory) {
     ThreadPoolExecutor executor = new ThreadPoolExecutor(corePoolSize, maxPoolSize,
         keepAliveTime, timeUnit, workQueue, threadFactory);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
-      executor.allowCoreThreadTimeOut(true);
-    }
+    executor.allowCoreThreadTimeOut(true);
     return executor;
   }
 

--- a/Parse/src/main/java/com/parse/PushService.java
+++ b/Parse/src/main/java/com/parse/PushService.java
@@ -211,7 +211,7 @@ public final class PushService extends Service {
   @Override
   public void onCreate() {
     super.onCreate();
-    if (ParsePlugins.Android.get() == null) {
+    if (ParsePlugins.get() == null) {
       PLog.e(TAG, "The Parse push service cannot start because Parse.initialize "
           + "has not yet been called. If you call Parse.initialize from "
           + "an Activity's onCreate, that call should instead be in the "

--- a/Parse/src/main/java/com/parse/PushServiceApi26.java
+++ b/Parse/src/main/java/com/parse/PushServiceApi26.java
@@ -9,7 +9,6 @@
 package com.parse;
 
 import android.annotation.TargetApi;
-import android.app.Service;
 import android.app.job.JobInfo;
 import android.app.job.JobParameters;
 import android.app.job.JobScheduler;
@@ -19,12 +18,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.IBinder;
-import android.os.PowerManager;
-import android.util.SparseArray;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -69,7 +63,7 @@ public final class PushServiceApi26 extends JobService {
 
   @Override
   public boolean onStartJob(final JobParameters jobParameters) {
-    if (ParsePlugins.Android.get() == null) {
+    if (ParsePlugins.get() == null) {
       PLog.e(TAG, "The Parse push service cannot start because Parse.initialize "
           + "has not yet been called. If you call Parse.initialize from "
           + "an Activity's onCreate, that call should instead be in the "

--- a/Parse/src/test/java/com/parse/NetworkQueryControllerTest.java
+++ b/Parse/src/test/java/com/parse/NetworkQueryControllerTest.java
@@ -73,7 +73,7 @@ public class NetworkQueryControllerTest {
     when(mockState.constraints()).thenReturn(new ParseQuery.QueryConstraints());
 
     NetworkQueryController controller = new NetworkQueryController(restClient);
-    Task<List<ParseObject>> findTask = controller.findAsync(mockState, "sessionToken", true, null);
+    Task<List<ParseObject>> findTask = controller.findAsync(mockState, "sessionToken", null);
     ParseTaskUtils.wait(findTask);
     List<ParseObject> objects = findTask.getResult();
 
@@ -103,7 +103,7 @@ public class NetworkQueryControllerTest {
 
     NetworkQueryController controller = new NetworkQueryController(restClient);
 
-    Task<Integer> countTask = controller.countAsync(mockState, "sessionToken", true, null);
+    Task<Integer> countTask = controller.countAsync(mockState, "sessionToken", null);
     ParseTaskUtils.wait(countTask);
     int count = countTask.getResult();
 

--- a/Parse/src/test/java/com/parse/ParseCorePluginsTest.java
+++ b/Parse/src/test/java/com/parse/ParseCorePluginsTest.java
@@ -32,7 +32,7 @@ public class ParseCorePluginsTest extends ResetPluginsParseTest {
     Parse.Configuration configuration = new Parse.Configuration.Builder(null)
             .applicationId("1234")
             .build();
-    ParsePlugins.initialize(configuration);
+    ParsePlugins.initialize(null, configuration);
   }
 
   @Test

--- a/Parse/src/test/java/com/parse/ParseInstallationTest.java
+++ b/Parse/src/test/java/com/parse/ParseInstallationTest.java
@@ -390,7 +390,7 @@ public class ParseInstallationTest extends ResetPluginsParseTest {
     ParseCorePlugins.getInstance().registerCurrentInstallationController(controller);
     // Mock App Name
     RuntimeEnvironment.application.getApplicationInfo().name = "parseTest";
-    ParsePlugins.Android plugins = mock(ParsePlugins.Android.class);
+    ParsePlugins plugins = mock(ParsePlugins.class);
     // Mock installationId
     InstallationId installationId = mock(InstallationId.class);
     when(installationId.get()).thenReturn("installationId");

--- a/Parse/src/test/java/com/parse/PushServiceTest.java
+++ b/Parse/src/test/java/com/parse/PushServiceTest.java
@@ -1,11 +1,7 @@
 package com.parse;
 
 
-import android.content.Context;
 import android.content.Intent;
-
-import com.google.protobuf.Service;
-import com.ibm.icu.impl.IllegalIcuArgumentException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -15,16 +11,11 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ServiceController;
 import org.robolectric.annotation.Config;
 
 import bolts.Task;
 import bolts.TaskCompletionSource;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -32,7 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 
 @RunWith(RobolectricTestRunner.class)
@@ -56,7 +46,7 @@ public class PushServiceTest extends ResetPluginsParseTest {
     service.setPushHandler(handler);
 
     Parse.Configuration.Builder builder = new Parse.Configuration.Builder(service);
-    ParsePlugins.Android.initialize(service, builder.build());
+    ParsePlugins.initialize(service, builder.build());
   }
 
   @After


### PR DESCRIPTION
Presently, the number of retries of a Parse command is always set to 5, and is not changeable. This allows you to set the number of max retries via the Parse.Configuration. Example:

```
 val config = Parse.Configuration.Builder(this)
                .applicationId("test")
                .clientKey("blah")
                .server("https://example.com/parse")
                .maxRetries(2)
                .build()
```
or even disable retries by setting `maxRetries(0)`