### PR TITLE
Add javadoc artifact to maven publication

### DIFF
--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -249,7 +249,7 @@ publishing {
             groupId group
             // We have to specify it here because otherwise Bintray's plugin will assume the artifact's name is Parse
             artifactId artifact
-            artifacts = [androidSourcesJar, bundleRelease]
+            artifacts = [androidSourcesJar, javadocJarRelease, bundleRelease]
             version version
             pom.withXml {
                 def root = asNode()


### PR DESCRIPTION
When publishing to maven, the javadocs will be uploaded automatically along with the sources.

Fixes issue:
* https://github.com/parse-community/docs/issues/486
* #783 

**Note:** I was not able to test this yet since I am waiting on my Sonatype account to be accepted. I have a test repository that I will try this with. However, I have been reading articles and I believe this will work.