### PR TITLE
Clean up authData when linkWithAsync() fails

### DIFF
--- a/Parse/src/main/java/com/parse/ParseUser.java
+++ b/Parse/src/main/java/com/parse/ParseUser.java
@@ -1294,6 +1294,7 @@ public class ParseUser extends ParseObject {
         public Task<Void> then(Task<Void> task) throws Exception {
           synchronized (mutex) {
             if (task.isFaulted() || task.isCancelled()) {
+              removeAuthData(authType);
               restoreAnonymity(oldAnonymousData);
               return task;
             }

--- a/Parse/src/test/java/com/parse/ParseUserTest.java
+++ b/Parse/src/test/java/com/parse/ParseUserTest.java
@@ -699,13 +699,13 @@ public class ParseUserTest extends ResetPluginsParseTest {
         partialMockUser.linkWithInBackground(authType, authData);
     linkTask.waitForCompletion();
 
-    // Make sure new authData is added
-    assertSame(authData, partialMockUser.getAuthData().get(authType));
     // Make sure we save the user
     verify(partialMockUser, times(1))
         .saveAsync(eq("sessionTokenAgain"), eq(false), Matchers.<Task<Void>>any());
     // Make sure old authData is restored
     assertSame(anonymousAuthData, partialMockUser.getAuthData().get(ParseAnonymousUtils.AUTH_TYPE));
+    // Make sure failed new authData is cleared
+    assertNull(partialMockUser.getAuthData().get("facebook"));
     // Verify exception
     assertSame(saveException, linkTask.getError());
   }


### PR DESCRIPTION
This was causing `isLinked(myAuthType)` to be true after a `linkWithAsync()` would fail for `myAuthType`, as explained in #767 

This PR would make the behavior on both iOS and Android the same.