### PR TITLE
Add automated docs in Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build
 testData
 testCache
 server.config
+docs/
 
 # Jacoco
 jacoco.exec

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_install:
     - mkdir "$ANDROID_HOME/licenses" || true
     - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
 
-script:
-  - ./gradlew clean testDebugUnitTest jacocoTestReport
-
 after_success:
   - ./gradlew coveralls
   - codecov
@@ -26,10 +23,22 @@ cache:
     - $HOME/.gradle
     - $HOME/.m2/repository
 
-deploy:
-  provider: script
-  script: ./gradlew bintrayUpload
-  skip_cleanup: true
-  on:
-    branch: master
-    tags: true
+jobs:
+  include:
+    - stage: test
+      script: ./gradlew clean testDebugUnitTest jacocoTestReport
+    - stage: release
+      script: ./gradlew javadocRelease
+      deploy:
+        - provider: pages
+          skip_cleanup: true
+          github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+          local_dir: docs/
+          on:
+            all_branches: true
+        - provider: script
+          script: ./gradlew bintrayUpload
+          skip_cleanup: true
+          on:
+            branch: master
+            tags: true

--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -157,6 +157,11 @@ signing {
     sign configurations.archives
 }
 
+//task androidTest(type: File) {
+//    Grgit.clone(dir: rootProject.file("docs"), uri: 'git://github.com/addisonElliott/Parse-SDK-Android.git', refToCheckout:'gh-pages')
+//    javadocRelease()
+//}
+
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'
     from android.sourceSets.main.java.sourceFiles

--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -69,7 +69,7 @@ android.libraryVariants.all { variant ->
 
     def javadoc = task("javadoc${variant.name.capitalize()}", type: Javadoc) {
         description "Generates Javadoc for $variant.name."
-        destinationDir = rootProject.file("docs")
+        destinationDir = rootProject.file("docs/api")
         source = variant.javaCompile.source
         ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
         classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
@@ -156,11 +156,6 @@ signing {
     required { !isSnapshot && gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
-
-//task androidTest(type: File) {
-//    Grgit.clone(dir: rootProject.file("docs"), uri: 'git://github.com/addisonElliott/Parse-SDK-Android.git', refToCheckout:'gh-pages')
-//    javadocRelease()
-//}
 
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'

--- a/Parse/build.gradle
+++ b/Parse/build.gradle
@@ -69,6 +69,7 @@ android.libraryVariants.all { variant ->
 
     def javadoc = task("javadoc${variant.name.capitalize()}", type: Javadoc) {
         description "Generates Javadoc for $variant.name."
+        destinationDir = rootProject.file("docs")
         source = variant.javaCompile.source
         ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
         classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)

--- a/Parse/src/main/java/com/parse/LogInCallback.java
+++ b/Parse/src/main/java/com/parse/LogInCallback.java
@@ -11,6 +11,7 @@ package com.parse;
 /**
  * A {@code LogInCallback} is used to run code after logging in a user.
  * <p/>
+ * Addison was here!!!!
  * The easiest way to use a {@code LogInCallback} is through an anonymous inner class. Override the
  * {@code done} function to specify what the callback should do after the login is complete.
  * The {@code done} function will be run in the UI thread, while the login happens in a

--- a/Parse/src/main/java/com/parse/LogInCallback.java
+++ b/Parse/src/main/java/com/parse/LogInCallback.java
@@ -11,7 +11,6 @@ package com.parse;
 /**
  * A {@code LogInCallback} is used to run code after logging in a user.
  * <p/>
- * Addison was here!!!!
  * The easiest way to use a {@code LogInCallback} is through an anonymous inner class. Override the
  * {@code done} function to specify what the callback should do after the login is complete.
  * The {@code done} function will be run in the UI thread, while the login happens in a


### PR DESCRIPTION
Updates gradle to create a docs/api directory on Travis deployment. Additionally, clean up Travis CI to have two stages, test and release. This stays consistent with JS and iOS branches that received an update already.

Use Travis pages provider to upload the docs directory.

**Note:** In Parse-SDK-JS and Parse-SDK-iOS, the publish docs scripts clone the Git repository before placing changes and uploading again. I'm not sure there is not any point to it. The pages provider does a force-push that does not store incremental changes for the docs.

Also, there is a new feature `keep-history` that will keep the previous history if incremental docs are desired. If desired, let me know and I will add it.

More info can be found [here](https://docs.travis-ci.com/user/deployment/pages/) and [here](https://github.com/travis-ci/travis-ci/issues/7562)

This code was tested on fork where I setup Travis CI. Docs can be seen [here](https://addisonelliott.github.io/Parse-SDK-Android/) and build can be seen [here](https://travis-ci.org/addisonElliott/Parse-SDK-Android)