### PR TITLE
Remove support for manifest configuration

### DIFF
--- a/Parse/src/main/java/com/parse/Parse.java
+++ b/Parse/src/main/java/com/parse/Parse.java
@@ -11,7 +11,7 @@ package com.parse;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import java.io.File;
@@ -59,59 +59,15 @@ public class Parse {
        * <p>
        * This context will then be passed through to the rest of the Parse SDK for use during
        * initialization.
-       * <p>
-       * <p/>
-       * You may define {@code com.parse.SERVER_URL}, {@code com.parse.APPLICATION_ID} and (optional) {@code com.parse.CLIENT_KEY}
-       * {@code meta-data} in your {@code AndroidManifest.xml}:
-       * <pre>
-       * &lt;manifest ...&gt;
-       *
-       * ...
-       *
-       *   &lt;application ...&gt;
-       *     &lt;meta-data
-       *       android:name="com.parse.SERVER_URL"
-       *       android:value="@string/parse_server_url" /&gt;
-       *     &lt;meta-data
-       *       android:name="com.parse.APPLICATION_ID"
-       *       android:value="@string/parse_app_id" /&gt;
-       *     &lt;meta-data
-       *       android:name="com.parse.CLIENT_KEY"
-       *       android:value="@string/parse_client_key" /&gt;
-       *
-       *       ...
-       *
-       *   &lt;/application&gt;
-       * &lt;/manifest&gt;
-       * </pre>
-       * <p/>
-       * <p>
-       * This will cause the values for {@code server}, {@code applicationId} and {@code clientKey} to be set to
-       * those defined in your manifest.
        *
        * @param context The active {@link Context} for your application. Cannot be null.
        */
-      public Builder(Context context) {
+      public Builder(@NonNull Context context) {
         this.context = context;
-
-        // Yes, our public API states we cannot be null. But for unit tests, it's easier just to
-        // support null here.
-        if (context != null) {
-          Context applicationContext = context.getApplicationContext();
-          Bundle metaData = ManifestInfo.getApplicationMetadata(applicationContext);
-          if (metaData != null) {
-            server(metaData.getString(PARSE_SERVER_URL));
-            applicationId = metaData.getString(PARSE_APPLICATION_ID);
-            clientKey = metaData.getString(PARSE_CLIENT_KEY);
-          }
-        }
       }
 
       /**
        * Set the application id to be used by Parse.
-       * <p>
-       * This method is only required if you intend to use a different {@code applicationId} than
-       * is defined by {@code com.parse.APPLICATION_ID} in your {@code AndroidManifest.xml}.
        *
        * @param applicationId The application id to set.
        * @return The same builder, for easy chaining.
@@ -123,9 +79,6 @@ public class Parse {
 
       /**
        * Set the client key to be used by Parse.
-       * <p>
-       * This method is only required if you intend to use a different {@code clientKey} than
-       * is defined by {@code com.parse.CLIENT_KEY} in your {@code AndroidManifest.xml}.
        *
        * @param clientKey The client key to set.
        * @return The same builder, for easy chaining.
@@ -224,10 +177,6 @@ public class Parse {
     }
   }
 
-  private static final String PARSE_SERVER_URL = "com.parse.SERVER_URL";
-  private static final String PARSE_APPLICATION_ID = "com.parse.APPLICATION_ID";
-  private static final String PARSE_CLIENT_KEY = "com.parse.CLIENT_KEY";
-
   private static final Object MUTEX = new Object();
   static ParseEventuallyQueue eventuallyQueue = null;
 
@@ -239,7 +188,7 @@ public class Parse {
   /**
    * Enable pinning in your application. This must be called before your application can use
    * pinning. You must invoke {@code enableLocalDatastore(Context)} before
-   * {@link #initialize(Context)} :
+   * {@link #initialize(Configuration)}:
    * <p/>
    * <pre>
    * public class MyApplication extends Application {
@@ -284,74 +233,6 @@ public class Parse {
 
   /**
    * Authenticates this client as belonging to your application.
-   * <p/>
-   * You may define {@code com.parse.SERVER_URL}, {@code com.parse.APPLICATION_ID} and (optional) {@code com.parse.CLIENT_KEY}
-   * {@code meta-data} in your {@code AndroidManifest.xml}:
-   * <pre>
-   * &lt;manifest ...&gt;
-   *
-   * ...
-   *
-   *   &lt;application ...&gt;
-   *     &lt;meta-data
-   *       android:name="com.parse.SERVER_URL"
-   *       android:value="@string/parse_server_url" /&gt;
-   *     &lt;meta-data
-   *       android:name="com.parse.APPLICATION_ID"
-   *       android:value="@string/parse_app_id" /&gt;
-   *     &lt;meta-data
-   *       android:name="com.parse.CLIENT_KEY"
-   *       android:value="@string/parse_client_key" /&gt;
-   *
-   *       ...
-   *
-   *   &lt;/application&gt;
-   * &lt;/manifest&gt;
-   * </pre>
-   * <p/>
-   * This must be called before your application can use the Parse library.
-   * The recommended way is to put a call to {@code Parse.initialize}
-   * in your {@code Application}'s {@code onCreate} method:
-   * <p/>
-   * <pre>
-   * public class MyApplication extends Application {
-   *   public void onCreate() {
-   *     Parse.initialize(this);
-   *   }
-   * }
-   * </pre>
-   *
-   * @param context The active {@link Context} for your application.
-   */
-  public static void initialize(Context context) {
-    Configuration.Builder builder = new Configuration.Builder(context);
-    if (builder.server == null) {
-      throw new RuntimeException("ServerUrl not defined. " +
-              "You must provide ServerUrl in AndroidManifest.xml.\n" +
-              "<meta-data\n" +
-              "    android:name=\"com.parse.SERVER_URL\"\n" +
-              "    android:value=\"<Your Server Url>\" />");
-    }
-    if (builder.applicationId == null) {
-      throw new RuntimeException("ApplicationId not defined. " +
-              "You must provide ApplicationId in AndroidManifest.xml.\n" +
-              "<meta-data\n" +
-              "    android:name=\"com.parse.APPLICATION_ID\"\n" +
-              "    android:value=\"<Your Application Id>\" />");
-    }
-    initialize(builder
-            .setLocalDatastoreEnabled(isLocalDatastoreEnabled)
-            .build()
-    );
-  }
-
-  /**
-   * Authenticates this client as belonging to your application.
-   * <p/>
-   * This method is only required if you intend to use a different {@code applicationId} or
-   * {@code clientKey} than is defined by {@code com.parse.APPLICATION_ID} or
-   * {@code com.parse.CLIENT_KEY} in your {@code AndroidManifest.xml}.
-   * <p/>
    * This must be called before your
    * application can use the Parse library. The recommended way is to put a call to
    * {@code Parse.initialize} in your {@code Application}'s {@code onCreate} method:
@@ -359,24 +240,13 @@ public class Parse {
    * <pre>
    * public class MyApplication extends Application {
    *   public void onCreate() {
-   *     Parse.initialize(this, &quot;your application id&quot;, &quot;your client key&quot;);
+   *     Parse.initialize(configuration);
    *   }
    * }
    * </pre>
    *
-   * @param context       The active {@link Context} for your application.
-   * @param applicationId The application id provided in the Parse dashboard.
-   * @param clientKey     The client key provided in the Parse dashboard.
+   * @param configuration The configuration for your application.
    */
-  public static void initialize(Context context, String applicationId, String clientKey) {
-    initialize(new Configuration.Builder(context)
-            .applicationId(applicationId)
-            .clientKey(clientKey)
-            .setLocalDatastoreEnabled(isLocalDatastoreEnabled)
-            .build()
-    );
-  }
-
   public static void initialize(Configuration configuration) {
     if (isInitialized()) {
       PLog.w(TAG, "Parse is already initialized");

--- a/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
+++ b/Parse/src/test/java/com/parse/ParseClientConfigurationTest.java
@@ -8,34 +8,17 @@
  */
 package com.parse;
 
-import android.os.Bundle;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-
-import java.net.URL;
-import java.util.Collection;
-import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = TestHelper.ROBOLECTRIC_SDK_VERSION)
 public class ParseClientConfigurationTest {
-
-  private final String serverUrl = "http://example.com/parse";
-  private final String appId = "MyAppId";
-  private final String clientKey = "MyClientKey";
-  private final String PARSE_SERVER_URL = "com.parse.SERVER_URL";
-  private final String PARSE_APPLICATION_ID = "com.parse.APPLICATION_ID";
-  private final String PARSE_CLIENT_KEY = "com.parse.CLIENT_KEY";
 
   @Test
   public void testBuilder() {
@@ -65,99 +48,5 @@ public class ParseClientConfigurationTest {
     builder.server("http://myserver.com/missingslash");
     Parse.Configuration configuration = builder.build();
     assertEquals(configuration.server, "http://myserver.com/missingslash/");
-  }
-
-  @Test
-  public void testConfigureFromManifest() throws Exception {
-    Bundle metaData = setupMockMetaData();
-    when(metaData.getString(PARSE_SERVER_URL)).thenReturn(serverUrl);
-    when(metaData.getString(PARSE_APPLICATION_ID)).thenReturn(appId);
-    when(metaData.getString(PARSE_CLIENT_KEY)).thenReturn(clientKey);
-
-    Parse.Configuration.Builder builder = new Parse.Configuration.Builder(RuntimeEnvironment.application);
-    Parse.Configuration config = builder.build();
-    assertEquals(serverUrl + "/", config.server);
-    assertEquals(appId, config.applicationId);
-    assertEquals(clientKey, config.clientKey);
-
-    verifyMockMetaData(metaData);
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testConfigureFromManifestWithoutServer() throws Exception {
-    Bundle metaData = setupMockMetaData();
-    when(metaData.getString(PARSE_SERVER_URL)).thenReturn(null);
-    when(metaData.getString(PARSE_APPLICATION_ID)).thenReturn(appId);
-    when(metaData.getString(PARSE_CLIENT_KEY)).thenReturn(clientKey);
-
-    // RuntimeException due to serverUrl = null
-    Parse.initialize(RuntimeEnvironment.application);
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testConfigureFromManifestWithoutAppId() throws Exception {
-    Bundle metaData = setupMockMetaData();
-    when(metaData.getString(PARSE_SERVER_URL)).thenReturn(serverUrl);
-    when(metaData.getString(PARSE_APPLICATION_ID)).thenReturn(null);
-    when(metaData.getString(PARSE_CLIENT_KEY)).thenReturn(clientKey);
-
-    // RuntimeException due to applicationId = null
-    Parse.initialize(RuntimeEnvironment.application);
-  }
-
-  @Test
-  public void testConfigureFromManifestWithoutClientKey() throws Exception {
-    Bundle metaData = setupMockMetaData();
-    when(metaData.getString(PARSE_SERVER_URL)).thenReturn(serverUrl);
-    when(metaData.getString(PARSE_APPLICATION_ID)).thenReturn(appId);
-    when(metaData.getString(PARSE_CLIENT_KEY)).thenReturn(null);
-
-    Parse.initialize(RuntimeEnvironment.application);
-    assertEquals(new URL(serverUrl + "/"), ParseRESTCommand.server);
-    assertEquals(appId, ParsePlugins.get().applicationId());
-    assertNull(ParsePlugins.get().clientKey());
-
-    verifyMockMetaData(metaData);
-  }
-
-  private void verifyMockMetaData(Bundle metaData) throws Exception {
-    verify(metaData).getString(PARSE_SERVER_URL);
-    verify(metaData).getString(PARSE_APPLICATION_ID);
-    verify(metaData).getString(PARSE_CLIENT_KEY);
-  }
-
-  private Bundle setupMockMetaData() throws Exception {
-    Bundle metaData = mock(Bundle.class);
-    RuntimeEnvironment.application.getApplicationInfo().metaData = metaData;
-    return metaData;
-  }
-
-  private static <T> boolean collectionsEqual(Collection<T> a, Collection<T> b) {
-    if (a.size() != b.size()) {
-      return false;
-    }
-
-    Iterator<T> iteratorA = a.iterator();
-    Iterator<T> iteratorB = b.iterator();
-    for (; iteratorA.hasNext() && iteratorB.hasNext();) {
-      T objectA = iteratorA.next();
-      T objectB = iteratorB.next();
-
-      if (objectA == null || objectB == null) {
-        if (objectA != objectB) {
-          return false;
-        }
-        continue;
-      }
-
-      if (!objectA.equals(objectB)) {
-        return false;
-      }
-    }
-
-    if (iteratorA.hasNext() || iteratorB.hasNext()) {
-      return false;
-    }
-    return true;
   }
 }

--- a/README.md
+++ b/README.md
@@ -36,28 +36,9 @@ For more information about Parse and its features, see [the website][parseplatfo
   
   You can link to your project to your AAR file as you please.
     
- ### Setup
-- **Option 1:** Setup in the Manifest
-
-  You may define `com.parse.SERVER_URL` and `com.parse.APPLICATION_ID` meta-data in your `AndroidManifest.xml`:
-
-  ```xml
-  <application ...>
-    <meta-data
-      android:name="com.parse.SERVER_URL"
-      android:value="@string/parse_server_url" />
-    <meta-data
-      android:name="com.parse.APPLICATION_ID"
-      android:value="@string/parse_app_id" />
-    ...
-  </application>
-  ```
-  
-- **Option 2:** Setup in the Application
-  
-  Initialize Parse in a custom class that extends `Application`:
-  
-  ```java
+### Setup
+Initialize Parse in a custom class that extends `Application`:
+```java
   import com.parse.Parse;
   import android.app.Application;
 
@@ -67,22 +48,23 @@ For more information about Parse and its features, see [the website][parseplatfo
       super.onCreate();
       Parse.initialize(new Parse.Configuration.Builder(this)
         .applicationId("YOUR_APP_ID")
+        .clientKey("YOUR_CLIENT_KEY")
         .server("http://localhost:1337/parse/")
         .build()
       );
     }
   }
-  ```
+```
   
- For either option, the custom `Application` class must be registered in `AndroidManifest.xml`:
+The custom `Application` class must be registered in `AndroidManifest.xml`:
  
- ```xml
- <application
-   android:name=".App"
-   ...>
-   ...
- </application>
- ```
+```xml
+<application
+    android:name=".App"
+    ...>
+    ...
+</application>
+```
 
 ## Usage
 Everything can done through the supplied gradle wrapper:

--- a/fcm/README.md
+++ b/fcm/README.md
@@ -56,7 +56,7 @@ After these services are registered in the Manifest, you then need to register y
 If you need to customize the notification that is sent out from a push, you can do so easily by extending `ParsePushBroadcastReceiver` with your own class and registering it instead in the Manifest.
 
 ## Instance ID Service
-If you need to store the FCM token elsewhere outside of Parse, you can create your own implementation of the `FirebaseInstanceIdService`, just make sure you are either extending `ParseFirebaseInstanceIdService` or are calling `ParseFCM.scheduleTokenUpload(getApplicationContext());` in the `onTokenRefresh` method.
+If you need to store the FCM token elsewhere outside of Parse, you can create your own implementation of the `FirebaseInstanceIdService`, just make sure you are either extending `ParseFirebaseInstanceIdService` or are calling `ParseFCM.register(getApplicationContext());` in the `onTokenRefresh` method.
 
 ## License
     Copyright (c) 2015-present, Parse, LLC.

--- a/fcm/src/main/java/com/parse/fcm/ParseFCM.java
+++ b/fcm/src/main/java/com/parse/fcm/ParseFCM.java
@@ -10,37 +10,22 @@ package com.parse.fcm;
 
 import android.content.Context;
 
-import com.firebase.jobdispatcher.Constraint;
 import com.firebase.jobdispatcher.FirebaseJobDispatcher;
 import com.firebase.jobdispatcher.GooglePlayDriver;
 import com.firebase.jobdispatcher.Job;
-import com.firebase.jobdispatcher.RetryStrategy;
 
 public class ParseFCM {
 
     static final String TAG = "ParseFCM";
 
-    private static final String JOB_TAG_UPLOAD_TOKEN = "upload-token";
-
     /**
      * You can call this manually if you are overriding the {@link com.google.firebase.iid.FirebaseInstanceIdService}
+     *
      * @param context context
      */
-    public static void scheduleTokenUpload(Context context) {
+    public static void register(Context context) {
         FirebaseJobDispatcher dispatcher = new FirebaseJobDispatcher(new GooglePlayDriver(context.getApplicationContext()));
-        Job job = dispatcher.newJobBuilder()
-                .setRecurring(false)
-                .setReplaceCurrent(true)
-                // retry with exponential backoff
-                .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
-                .setConstraints(
-                        // only run on a network
-                        Constraint.ON_ANY_NETWORK
-                )
-                .setService(ParseFirebaseJobService.class) // the JobService that will be called
-                .setTag(JOB_TAG_UPLOAD_TOKEN)        // uniquely identifies the job
-                .build();
-
+        Job job = ParseFirebaseJobService.createJob(dispatcher);
         dispatcher.mustSchedule(job);
     }
 }

--- a/fcm/src/main/java/com/parse/fcm/ParseFirebaseInstanceIdService.java
+++ b/fcm/src/main/java/com/parse/fcm/ParseFirebaseInstanceIdService.java
@@ -23,6 +23,6 @@ public class ParseFirebaseInstanceIdService extends FirebaseInstanceIdService {
     @Override
     public void onTokenRefresh() {
         super.onTokenRefresh();
-        ParseFCM.scheduleTokenUpload(getApplicationContext());
+        ParseFCM.register(getApplicationContext());
     }
 }

--- a/fcm/src/main/java/com/parse/fcm/ParseFirebaseJobService.java
+++ b/fcm/src/main/java/com/parse/fcm/ParseFirebaseJobService.java
@@ -8,8 +8,12 @@
  */
 package com.parse.fcm;
 
+import com.firebase.jobdispatcher.Constraint;
+import com.firebase.jobdispatcher.FirebaseJobDispatcher;
+import com.firebase.jobdispatcher.Job;
 import com.firebase.jobdispatcher.JobParameters;
 import com.firebase.jobdispatcher.JobService;
+import com.firebase.jobdispatcher.RetryStrategy;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.parse.PLog;
 import com.parse.ParseException;
@@ -20,6 +24,23 @@ import com.parse.SaveCallback;
  * Handles saving the FCM token to the {@link ParseInstallation} in the background
  */
 public class ParseFirebaseJobService extends JobService {
+
+    private static final String JOB_TAG_UPLOAD_TOKEN = "upload-token";
+
+    static Job createJob(FirebaseJobDispatcher dispatcher) {
+        return dispatcher.newJobBuilder()
+                .setRecurring(false)
+                .setReplaceCurrent(true)
+                // retry with exponential backoff
+                .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
+                .setConstraints(
+                        // only run on a network
+                        Constraint.ON_ANY_NETWORK
+                )
+                .setService(ParseFirebaseJobService.class) // the JobService that will be called
+                .setTag(JOB_TAG_UPLOAD_TOKEN)        // uniquely identifies the job
+                .build();
+    }
 
     @Override
     public boolean onStartJob(final JobParameters job) {

--- a/gcm/README.md
+++ b/gcm/README.md
@@ -16,15 +16,7 @@ dependencies {
     implementation 'com.parse:parse-android-gcm:latest.version.here'
 }
 ```
-You will then need to register some things in your manifest, firstly, the GCM sender ID:
-```xml
-<meta-data
-    android:name="com.parse.push.gcm_sender_id"
-    android:value="id:YOUR_SENDER_ID_HERE" />
-```
-The sender ID should be all numbers. Make sure you are keeping the `id:` in the front
-
-Next:
+You will then need to register some things in your manifest, firstly:
 ```xml
 <receiver
     android:name="com.google.android.gms.gcm.GcmReceiver"
@@ -69,7 +61,7 @@ After these services are registered in the Manifest, you then need to register y
     </intent-filter>
 </receiver>
 ```
-After all this, you will need to register GCM in your `Application.onCreate()` like so:
+After all this, you will need to register for GCM in your `Application.onCreate()`, like so:
 ```java
 @Override
 public void onCreate() {
@@ -78,9 +70,10 @@ public void onCreate() {
             //...
             .build();
     Parse.initialize(configuration);
-    ParseGCM.register(this);
+    ParseGCM.register(this, gcmSenderId);
 }
 ```
+The sender ID should be all numbers. It is obtained via the Firebase console.
 
 After this, you are all set.
 

--- a/gcm/README.md
+++ b/gcm/README.md
@@ -16,7 +16,15 @@ dependencies {
     implementation 'com.parse:parse-android-gcm:latest.version.here'
 }
 ```
-You will then need to register some things in your manifest, firstly:
+You will then need to register some things in your manifest, firstly, the GCM sender ID:
+```xml
+<meta-data
+    android:name="com.parse.push.gcm_sender_id"
+    android:value="id:YOUR_SENDER_ID_HERE" />
+```
+The sender ID should be all numbers. Make sure you are keeping the `id:` in the front.
+
+Next you will register the GcmReceiver:
 ```xml
 <receiver
     android:name="com.google.android.gms.gcm.GcmReceiver"

--- a/gcm/src/main/java/com/parse/gcm/ParseGCM.java
+++ b/gcm/src/main/java/com/parse/gcm/ParseGCM.java
@@ -9,15 +9,11 @@
 package com.parse.gcm;
 
 import android.content.Context;
-import android.os.Bundle;
-import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
 
-import com.firebase.jobdispatcher.Constraint;
 import com.firebase.jobdispatcher.FirebaseJobDispatcher;
 import com.firebase.jobdispatcher.GooglePlayDriver;
 import com.firebase.jobdispatcher.Job;
-import com.firebase.jobdispatcher.RetryStrategy;
-import com.parse.ManifestInfo;
 import com.parse.PLog;
 
 /**
@@ -25,88 +21,19 @@ import com.parse.PLog;
  */
 public class ParseGCM {
 
-    private static final String SENDER_ID_EXTRA = "com.parse.push.gcm_sender_id";
-
     static final String TAG = "ParseGCM";
-
-    private static final String JOB_TAG_REGISTER = "register";
 
     /**
      * Register your app to start receiving GCM pushes
      *
-     * @param context context
+     * @param context     context
+     * @param gcmSenderId the GCM sender ID from the Firebase console
      */
-    public static void register(Context context) {
+    public static void register(@NonNull Context context, @NonNull String gcmSenderId) {
         //kicks off the background job
         PLog.v(TAG, "Scheduling job to register Parse GCM");
         FirebaseJobDispatcher dispatcher = new FirebaseJobDispatcher(new GooglePlayDriver(context.getApplicationContext()));
-        Job job = dispatcher.newJobBuilder()
-                .setRecurring(false)
-                .setReplaceCurrent(true)
-                // retry with exponential backoff
-                .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
-                .setConstraints(
-                        // only run on a network
-                        Constraint.ON_ANY_NETWORK
-                )
-                .setService(ParseGCMJobService.class) // the JobService that will be called
-                .setTag(JOB_TAG_REGISTER)        // uniquely identifies the job
-                .build();
-
+        Job job = ParseGCMJobService.createJob(dispatcher, gcmSenderId);
         dispatcher.mustSchedule(job);
-    }
-
-    @Nullable
-    static String gcmSenderFromManifest(Context context) {
-        // Look for an element like this as a child of the <application> element:
-        //
-        //   <meta-data android:name="com.parse.push.gcm_sender_id"
-        //              android:value="id:567327206255" />
-        //
-        // The reason why the "id:" prefix is necessary is because Android treats any metadata value
-        // that is a string of digits as an integer. So the call to Bundle.getString() will actually
-        // return null for `android:value="567327206255"`. Additionally, Bundle.getInteger() returns
-        // a 32-bit integer. For `android:value="567327206255"`, this returns a truncated integer
-        // because 567327206255 is larger than the largest 32-bit integer.
-        Bundle metaData = ManifestInfo.getApplicationMetadata(context);
-        String senderID = null;
-
-        if (metaData != null) {
-            Object senderIDExtra = metaData.get(SENDER_ID_EXTRA);
-
-            if (senderIDExtra != null) {
-                senderID = actualSenderIDFromExtra(senderIDExtra);
-
-                if (senderID == null) {
-                    PLog.e(TAG, "Found " + SENDER_ID_EXTRA + " <meta-data> element with value \"" +
-                            senderIDExtra.toString() + "\", but the value is missing the expected \"id:\" " +
-                            "prefix.");
-                    return null;
-                }
-            }
-        }
-
-        if (senderID == null) {
-            PLog.e(TAG, "You must provide " + SENDER_ID_EXTRA + " in your AndroidManifest.xml\n" +
-                    "Make sure to prefix with the value with id:\n\n" +
-                    "<meta-data\n" +
-                    "    android:name=\"com.parse.push.gcm_sender_id\"\n" +
-                    "    android:value=\"id:<YOUR_GCM_SENDER_ID>\" />");
-            return null;
-        }
-        return senderID;
-    }
-
-    private static String actualSenderIDFromExtra(Object senderIDExtra) {
-        if (!(senderIDExtra instanceof String)) {
-            return null;
-        }
-
-        String senderID = (String) senderIDExtra;
-        if (!senderID.startsWith("id:")) {
-            return null;
-        }
-
-        return senderID.substring(3);
     }
 }

--- a/gcm/src/main/java/com/parse/gcm/ParseGCM.java
+++ b/gcm/src/main/java/com/parse/gcm/ParseGCM.java
@@ -9,11 +9,14 @@
 package com.parse.gcm;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import com.firebase.jobdispatcher.FirebaseJobDispatcher;
 import com.firebase.jobdispatcher.GooglePlayDriver;
 import com.firebase.jobdispatcher.Job;
+import com.parse.ManifestInfo;
 import com.parse.PLog;
 
 /**
@@ -23,17 +26,72 @@ public class ParseGCM {
 
     static final String TAG = "ParseGCM";
 
+    private static final String SENDER_ID_EXTRA = "com.parse.push.gcm_sender_id";
+
     /**
      * Register your app to start receiving GCM pushes
      *
      * @param context     context
-     * @param gcmSenderId the GCM sender ID from the Firebase console
      */
-    public static void register(@NonNull Context context, @NonNull String gcmSenderId) {
+    public static void register(@NonNull Context context) {
         //kicks off the background job
         PLog.v(TAG, "Scheduling job to register Parse GCM");
         FirebaseJobDispatcher dispatcher = new FirebaseJobDispatcher(new GooglePlayDriver(context.getApplicationContext()));
-        Job job = ParseGCMJobService.createJob(dispatcher, gcmSenderId);
+        Job job = ParseGCMJobService.createJob(dispatcher, gcmSenderFromManifest(context));
         dispatcher.mustSchedule(job);
+    }
+
+    @Nullable
+    private static String gcmSenderFromManifest(Context context) {
+        // Look for an element like this as a child of the <application> element:
+        //
+        //   <meta-data android:name="com.parse.push.gcm_sender_id"
+        //              android:value="id:567327206255" />
+        //
+        // The reason why the "id:" prefix is necessary is because Android treats any metadata value
+        // that is a string of digits as an integer. So the call to Bundle.getString() will actually
+        // return null for `android:value="567327206255"`. Additionally, Bundle.getInteger() returns
+        // a 32-bit integer. For `android:value="567327206255"`, this returns a truncated integer
+        // because 567327206255 is larger than the largest 32-bit integer.
+        Bundle metaData = ManifestInfo.getApplicationMetadata(context);
+        String senderID = null;
+
+        if (metaData != null) {
+            Object senderIDExtra = metaData.get(SENDER_ID_EXTRA);
+
+            if (senderIDExtra != null) {
+                senderID = actualSenderIDFromExtra(senderIDExtra);
+
+                if (senderID == null) {
+                    PLog.e(TAG, "Found " + SENDER_ID_EXTRA + " <meta-data> element with value \"" +
+                            senderIDExtra.toString() + "\", but the value is missing the expected \"id:\" " +
+                            "prefix.");
+                    return null;
+                }
+            }
+        }
+
+        if (senderID == null) {
+            PLog.e(TAG, "You must provide " + SENDER_ID_EXTRA + " in your AndroidManifest.xml\n" +
+                    "Make sure to prefix with the value with id:\n\n" +
+                    "<meta-data\n" +
+                    "    android:name=\"com.parse.push.gcm_sender_id\"\n" +
+                    "    android:value=\"id:<YOUR_GCM_SENDER_ID>\" />");
+            return null;
+        }
+        return senderID;
+    }
+
+    private static String actualSenderIDFromExtra(Object senderIDExtra) {
+        if (!(senderIDExtra instanceof String)) {
+            return null;
+        }
+
+        String senderID = (String) senderIDExtra;
+        if (!senderID.startsWith("id:")) {
+            return null;
+        }
+
+        return senderID.substring(3);
     }
 }

--- a/gcm/src/main/java/com/parse/gcm/ParseGCMInstanceIDListenerService.java
+++ b/gcm/src/main/java/com/parse/gcm/ParseGCMInstanceIDListenerService.java
@@ -1,10 +1,5 @@
 package com.parse.gcm;
 
-import com.firebase.jobdispatcher.Constraint;
-import com.firebase.jobdispatcher.FirebaseJobDispatcher;
-import com.firebase.jobdispatcher.GooglePlayDriver;
-import com.firebase.jobdispatcher.Job;
-import com.firebase.jobdispatcher.RetryStrategy;
 import com.google.android.gms.iid.InstanceIDListenerService;
 
 /**
@@ -15,7 +10,6 @@ public class ParseGCMInstanceIDListenerService extends InstanceIDListenerService
     @Override
     public void onTokenRefresh() {
         super.onTokenRefresh();
-
         ParseGCM.register(getApplicationContext());
     }
 }


### PR DESCRIPTION
The ability to configure the server in the manifest is a sort of relic of when the SDK was being used with Parse.com. In order to move forward with allowing for customization, as well as adding new plugins such as FCM support, I think it is best that in the 1.17.0 release we ditch the Manifest configuration. This is the best time to do it, since 1.17.0 has API breaking changes which, if users are using GCM, will require them to update their Manifest and code anyhow. 

We certainly would want to make sure it is clear in the release notes that this is occurring.