### PR TITLE
Set installation to fcm now.

### DIFF
--- a/fcm/src/main/java/com/parse/fcm/ParseFirebaseJobService.java
+++ b/fcm/src/main/java/com/parse/fcm/ParseFirebaseJobService.java
@@ -26,6 +26,7 @@ import com.parse.SaveCallback;
 public class ParseFirebaseJobService extends JobService {
 
     private static final String JOB_TAG_UPLOAD_TOKEN = "upload-token";
+    private static final String PUSH_TYPE = "fcm";
 
     static Job createJob(FirebaseJobDispatcher dispatcher) {
         return dispatcher.newJobBuilder()
@@ -50,7 +51,7 @@ public class ParseFirebaseJobService extends JobService {
         if (installation != null && token != null) {
             installation.setDeviceToken(token);
             //even though this is FCM, calling it gcm will work on the backend
-            installation.setPushType("gcm");
+            installation.setPushType(PUSH_TYPE);
             installation.saveInBackground(new SaveCallback() {
                 @Override
                 public void done(ParseException e) {


### PR DESCRIPTION
The push adapter actually ignores the push type and falls back to the device type.  It should be OK to classify these pushes as FCM.  

i.e. this line falls back to using the android deviceMap:

https://github.com/parse-community/parse-server-push-adapter/blob/master/src/PushAdapterUtils.js#L20

The only accepted types are actually `android` and `fcm`:

https://github.com/parse-community/parse-server-push-adapter/blob/master/src/ParsePushAdapter.js#L35

We should move off the parse-server GCM module because the FCM sending needs a service account and database URL instead of a GCM sender ID.