### PR TITLE
Revert "Set installation to fcm now. (#820)"

### DIFF
--- a/fcm/src/main/java/com/parse/fcm/ParseFirebaseJobService.java
+++ b/fcm/src/main/java/com/parse/fcm/ParseFirebaseJobService.java
@@ -26,7 +26,6 @@ import com.parse.SaveCallback;
 public class ParseFirebaseJobService extends JobService {
 
     private static final String JOB_TAG_UPLOAD_TOKEN = "upload-token";
-    private static final String PUSH_TYPE = "fcm";
 
     static Job createJob(FirebaseJobDispatcher dispatcher) {
         return dispatcher.newJobBuilder()
@@ -51,7 +50,7 @@ public class ParseFirebaseJobService extends JobService {
         if (installation != null && token != null) {
             installation.setDeviceToken(token);
             //even though this is FCM, calling it gcm will work on the backend
-            installation.setPushType(PUSH_TYPE);
+            installation.setPushType("gcm");
             installation.saveInBackground(new SaveCallback() {
                 @Override
                 public void done(ParseException e) {


### PR DESCRIPTION
This reverts commit f3d47f6eb1a03240ad48fd10b35d75b61d8c48ff.

Making this change requires parse-server to set push config to be `fcm` in addition to `android`:

i.e.

```javascript
"push": { "fcm": { "senderId": "XXXX", "apiKey": "XXXX" }, "android": { "senderId": "XXXX", "apiKey": "XXXX" }}
```

If your push configuration is set to only 'android' type, then there will be no corresponding push adapter and pushes of this type will fail.

I'm conflicted here... on one hand, it's better to keep track of FCM pushes separately.  On the other hand, is it reasonable to ask people to upgrade their Parse servers to include this change too?

@flovilmart @Jawnnypoo 