### PR TITLE
Match up all docs with artifact names

### DIFF
--- a/fcm/README.md
+++ b/fcm/README.md
@@ -10,7 +10,7 @@ Add dependency to the application level `build.gradle` file.
 ```groovy
 dependencies {
     implementation 'com.parse:parse-android:latest.version.here'
-    implementation 'com.parse:parse-android-fcm:latest.version.here'
+    implementation 'com.parse:parse-fcm-android:latest.version.here'
 }
 ```
 Then, follow Google's docs for [setting up an Firebase app](https://firebase.google.com/docs/android/setup). Although the steps are different for setting up FCM with Parse, it is also a good idea to read over the [Firebase FCM Setup](https://firebase.google.com/docs/cloud-messaging/android/client).

--- a/gcm/README.md
+++ b/gcm/README.md
@@ -13,7 +13,7 @@ Add dependency to the application level `build.gradle` file.
 ```groovy
 dependencies {
     implementation 'com.parse:parse-android:latest.version.here'
-    implementation 'com.parse:parse-android-gcm:latest.version.here'
+    implementation 'com.parse:parse-gcm-android:latest.version.here'
 }
 ```
 You will then need to register some things in your manifest, firstly, the GCM sender ID:

--- a/gcm/build.gradle
+++ b/gcm/build.gradle
@@ -5,7 +5,7 @@ group = 'com.parse'
 
 ext {
     projDescription = 'Parse Android GCM support.'
-    artifact = 'parse-android-gcm'
+    artifact = 'parse-gcm-android'
     projName = 'Parse-Android'
     gitLink = 'https://github.com/parse-community/Parse-SDK-Android'
 }


### PR DESCRIPTION
Okay, this gets all the names in sync. `parse-gcm-android` and `parse-fcm-android`. Personally not the biggest fan of this naming scheme, but since it is already established with other packages, this corrects to that format. 