### PR TITLE
Improved exception handling in EventuallyPin.findAllPinned()

### DIFF
--- a/Parse/src/main/java/com/parse/EventuallyPin.java
+++ b/Parse/src/main/java/com/parse/EventuallyPin.java
@@ -166,7 +166,7 @@ class EventuallyPin extends ParseObject {
 
     // We need pass in a null user because we don't want the query to fetch the current user
     // from LDS.
-    return query.findInBackground().continueWithTask(new Continuation<List<EventuallyPin>, Task<List<EventuallyPin>>>() {
+    return query.findInBackground().onSuccessTask(new Continuation<List<EventuallyPin>, Task<List<EventuallyPin>>>() {
       @Override
       public Task<List<EventuallyPin>> then(Task<List<EventuallyPin>> task) throws Exception {
         final List<EventuallyPin> pins = task.getResult();

--- a/Parse/src/test/java/com/parse/EventuallyPinTest.java
+++ b/Parse/src/test/java/com/parse/EventuallyPinTest.java
@@ -1,0 +1,59 @@
+package com.parse;
+
+import android.database.sqlite.SQLiteException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import bolts.Task;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = TestHelper.ROBOLECTRIC_SDK_VERSION)
+public class EventuallyPinTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void setUp() throws Exception {
+    ParseObject.registerSubclass(EventuallyPin.class);
+    ParseObject.registerSubclass(ParsePin.class);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    ParseObject.unregisterSubclass(EventuallyPin.class);
+    ParseObject.unregisterSubclass(ParsePin.class);
+    Parse.setLocalDatastore(null);
+    ParsePlugins.reset();
+  }
+
+  @Test
+  public void testFailingFindAllPinned() throws Exception {
+    OfflineStore offlineStore = mock(OfflineStore.class);
+    Parse.setLocalDatastore(offlineStore);
+    when(offlineStore.findFromPinAsync(eq(EventuallyPin.PIN_NAME),
+        any(ParseQuery.State.class),
+        any(ParseUser.class)))
+        .thenReturn(Task.forError(new SQLiteException()));
+
+    ParsePlugins plugins = mock(ParsePlugins.class);
+    ParsePlugins.set(plugins);
+    when(plugins.restClient()).thenReturn(ParseHttpClient.createClient(null));
+
+    thrown.expect(SQLiteException.class);
+
+    ParseTaskUtils.wait(EventuallyPin.findAllPinned());
+  }
+}


### PR DESCRIPTION
The code in the callback starting at [L172](https://github.com/DanGTZ/Parse-SDK-Android/blob/26c80e68e79b373dd151287f1bdc3add6e9fa19b/Parse/src/main/java/com/parse/EventuallyPin.java#L172) doesn't check if the task is faulted, and assumes it's successful by iterating over the result's list.
So there is a potential null pointer exception at [L175](https://github.com/DanGTZ/Parse-SDK-Android/blob/26c80e68e79b373dd151287f1bdc3add6e9fa19b/Parse/src/main/java/com/parse/EventuallyPin.java#L175).
Also in other parts of the sdk onSuccessTask is used for the same case : https://github.com/parse-community/Parse-SDK-Android/blob/e86b920a001e9b184aa7d7f81cad00abcbe2afe8/Parse/src/main/java/com/parse/ParsePinningEventuallyQueue.java#L583