### PR TITLE
Fix broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
 # Parse SDK for Android
 
-[![Bintray][bintray-svg]][bintray-link]
-[![License][license-svg]][license-link]
-[![Build Status][build-status-svg]][build-status-link]
-[![Coverage Status][coverage-status-svg]][coverage-status-link]
-[![Join Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/ParsePlatform/Chat)
-[![](https://jitpack.io/v/parse-community/Parse-SDK-Android.svg)](https://jitpack.io/#parse-community/Parse-SDK-Android)
+[![License][license-svg]][license-link] [![Build Status][build-status-svg]][build-status-link] [![Join Chat](https://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/ParsePlatform/Chat) [![](https://jitpack.io/v/parse-community/Parse-SDK-Android.svg)](https://jitpack.io/#parse-community/Parse-SDK-Android)
 
 A library that gives you access to the powerful Parse cloud platform from your Android app.
 For more information about Parse and its features, see [the website][parseplatform.org], [blog][blog] and [getting started][guide].


### PR DESCRIPTION
Bintray link no longer applicable. Coverage link seems to have been broken for a while for some reason