### PR TITLE
Return null result properly for cloud function

### DIFF
--- a/parse/src/main/java/com/parse/ParseCloudCodeController.java
+++ b/parse/src/main/java/com/parse/ParseCloudCodeController.java
@@ -45,6 +45,10 @@ class ParseCloudCodeController {
     /* package for test */ Object convertCloudResponse(Object result) {
         if (result instanceof JSONObject) {
             JSONObject jsonResult = (JSONObject) result;
+            // We want to make sure we pass back a null result as null, and not a JSONObject
+            if (jsonResult.isNull("result")) {
+                return null;
+            }
             result = jsonResult.opt("result");
         }
 

--- a/parse/src/test/java/com/parse/ParseCloudCodeControllerTest.java
+++ b/parse/src/test/java/com/parse/ParseCloudCodeControllerTest.java
@@ -185,6 +185,28 @@ public class ParseCloudCodeControllerTest {
 
     //endregion
 
+    @Test
+    public void testCallFunctionWithNullResult() throws Exception {
+        String content = "{ result: null }";
+
+        ParseHttpResponse mockResponse = new ParseHttpResponse.Builder()
+                .setStatusCode(200)
+                .setTotalSize((long) content.length())
+                .setContent(new ByteArrayInputStream(content.getBytes()))
+                .build();
+
+        ParseHttpClient restClient = mockParseHttpClientWithReponse(mockResponse);
+        ParseCloudCodeController controller = new ParseCloudCodeController(restClient);
+
+        Task<String> cloudCodeTask = controller.callFunctionInBackground(
+                "test", new HashMap<String, Object>(), "sessionToken");
+        ParseTaskUtils.wait(cloudCodeTask);
+
+        verify(restClient, times(1)).execute(any(ParseHttpRequest.class));
+        String result = cloudCodeTask.getResult();
+        assertEquals(null, result);
+    }
+
     private ParseHttpClient mockParseHttpClientWithReponse(ParseHttpResponse response)
             throws IOException {
         ParseHttpClient client = mock(ParseHttpClient.class);


### PR DESCRIPTION
Presently, the result:
```
{
   "result": null
}
```
will be returned as a JSONObject. This causes issues, considering that if you were to call:
```
val result = ParseCloud.callFunction<String?>("functionNameThatReturnsStringOrNull", null)
val invalid = result == null
```
^ this will always fail, due to the fact that `JSONObject` will be returned instead of `null`

This fixes this and returns null if the `result` is null in the response. 