### PR TITLE
Null headers

### DIFF
--- a/parse/src/main/java/com/parse/ManifestInfo.java
+++ b/parse/src/main/java/com/parse/ManifestInfo.java
@@ -61,6 +61,7 @@ public class ManifestInfo {
                     versionName = getPackageManager().getPackageInfo(getContext().getPackageName(), 0).versionName;
                 } catch (NameNotFoundException e) {
                     PLog.e(TAG, "Couldn't find info about own package", e);
+                    versionName = "unknown";
                 }
             }
         }


### PR DESCRIPTION
It is unclear what can cause this, but if a header happens to have a null value, OkHttp throws an exception. We can instead just ignore these headers. This will in turn fix #848