### PR TITLE
Update README.md

### DIFF
--- a/fcm/README.md
+++ b/fcm/README.md
@@ -29,7 +29,7 @@ Additional, you will register:
 
 ```xml
 <service
-    android:name="com.parse.fcm.ParseFirebaseMessagingService"
+    android:name="com.parse.fcm.ParseFirebaseMessagingService">
     <intent-filter>
         <action android:name="com.google.firebase.MESSAGING_EVENT"/>
     </intent-filter>


### PR DESCRIPTION
The service definition "com.parse.fcm.ParseFirebaseMessagingService" was missing the ">" character at the end, causing error in AndroidManifest.xmll