### PR TITLE
Fix StackOverflowError when merging ParseObject from JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 before_install:
     - pip install --user codecov
     - mkdir "$ANDROID_HOME/licenses" || true
-    - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+    - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
 
 script:
   - ./gradlew clean testDebugUnitTest jacocoTestReport

--- a/parse/src/main/java/com/parse/ParseObject.java
+++ b/parse/src/main/java/com/parse/ParseObject.java
@@ -4076,7 +4076,7 @@ public class ParseObject implements Parcelable {
                 objectId = state.objectId();
                 createdAt = state.createdAt();
                 updatedAt = state.updatedAt();
-                availableKeys = Collections.synchronizedSet(state.availableKeys());
+                availableKeys = Collections.synchronizedSet(new HashSet<>(state.availableKeys()));
                 for (String key : state.keySet()) {
                     serverData.put(key, state.get(key));
                     availableKeys.add(key);

--- a/parse/src/test/java/com/parse/ParseObjectTest.java
+++ b/parse/src/test/java/com/parse/ParseObjectTest.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -128,7 +129,7 @@ public class ParseObjectTest {
 
     //endregion
 
-    //region testGetter
+    //region testFromJson
 
     @Test
     public void testFromJSONPayloadWithoutClassname() throws JSONException {
@@ -136,6 +137,30 @@ public class ParseObjectTest {
         ParseObject parseObject = ParseObject.fromJSONPayload(json, ParseDecoder.get());
         assertNull(parseObject);
     }
+
+    @Test
+    public void testFromJsonWithLdsStackOverflow() throws JSONException {
+        ParseObject localObj = ParseObject.createWithoutData("GameScore", "TT1ZskATqS");
+        OfflineStore lds = mock(OfflineStore.class);
+        Parse.setLocalDatastore(lds);
+
+        when(lds.getObject(eq("GameScore"), eq("TT1ZskATqS"))).thenReturn(localObj);
+
+        JSONObject json = new JSONObject("{" +
+                "\"className\":\"GameScore\"," +
+                "\"createdAt\":\"2015-06-22T21:23:41.733Z\"," +
+                "\"objectId\":\"TT1ZskATqS\"," +
+                "\"updatedAt\":\"2015-06-22T22:06:18.104Z\"" +
+                "}");
+        ParseObject obj;
+        for (int i = 0; i < 50000; i++) {
+            obj = ParseObject.fromJSON(json, "GameScore", ParseDecoder.get(), Collections.<String>emptySet());
+        }
+    }
+
+    //endregion
+
+    //region testGetter
 
     @Test
     public void testRevert() throws ParseException {


### PR DESCRIPTION
This fixes #896.  See comments there, and at #795.

When LocalDataStore is enabled, the same `ParseObject(.State)` is shared for the same class+id pair. That allows us to update objects in-place whenever a ParseObject is parsed from JSON.  But every time the state is copied, via `State.newBuilder()`, the `availableKeys` Set is wrapped (and re-wrapped, etc...) in synchronizedSet().

Eventually, if the object has been refreshed enough times, that results in such a deeply nested hierarchy of wrapped sets, that any collection operation on it results in a StackOverflowError.

This change adds a test to prove the bug, and fixes it by severing making a copy of the set before wrapping it in synchronizedSet().