### PR TITLE
Convert project to use AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.21'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -28,12 +28,10 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 27
-
-    supportLibVersion = '27.1.1'
+    compileSdkVersion = 28
 
     firebaseJobdispatcherVersion = '0.8.5'
 
     minSdkVersion = 14
-    targetSdkVersion = 27
+    targetSdkVersion = 28
 }

--- a/fcm/build.gradle
+++ b/fcm/build.gradle
@@ -9,7 +9,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
 

--- a/fcm/src/main/java/com/parse/fcm/ParseFirebaseInstanceIdService.java
+++ b/fcm/src/main/java/com/parse/fcm/ParseFirebaseInstanceIdService.java
@@ -8,7 +8,7 @@
  */
 package com.parse.fcm;
 
-import android.support.annotation.CallSuper;
+import androidx.annotation.CallSuper;
 
 import com.google.firebase.iid.FirebaseInstanceIdService;
 import com.parse.ParseInstallation;

--- a/gcm/build.gradle
+++ b/gcm/build.gradle
@@ -9,7 +9,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
 

--- a/gcm/src/main/java/com/parse/gcm/ParseGCM.java
+++ b/gcm/src/main/java/com/parse/gcm/ParseGCM.java
@@ -10,8 +10,8 @@ package com.parse.gcm;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.firebase.jobdispatcher.FirebaseJobDispatcher;
 import com.firebase.jobdispatcher.GooglePlayDriver;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,6 @@
-#Tue Aug 22 15:11:42 CDT 2017
+#Thu Feb 14 09:49:29 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-# Make sure to update the version of android-maven-publish if you bump the Gradle version
-# See: https://github.com/wupdigital/android-maven-publish
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/ktx/build.gradle
+++ b/ktx/build.gradle
@@ -11,7 +11,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     }
 

--- a/parse/build.gradle
+++ b/parse/build.gradle
@@ -28,12 +28,12 @@ android {
 }
 
 ext {
-    okhttpVersion = '3.11.0'
+    okhttpVersion = '3.12.1'
 }
 
 dependencies {
-    api "com.android.support:support-annotations:$supportLibVersion"
-    api "com.android.support:support-compat:$supportLibVersion"
+    api "androidx.annotation:annotation:1.0.1"
+    api "androidx.core:core:1.0.1"
     api 'com.parse.bolts:bolts-tasks:1.4.0'
     api "com.squareup.okhttp3:okhttp:$okhttpVersion"
 

--- a/parse/src/main/java/com/parse/Parse.java
+++ b/parse/src/main/java/com/parse/Parse.java
@@ -11,7 +11,7 @@ package com.parse;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.io.File;

--- a/parse/src/main/java/com/parse/ParseHttpClient.java
+++ b/parse/src/main/java/com/parse/ParseHttpClient.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.parse.http.ParseHttpBody;
 import com.parse.http.ParseHttpRequest;

--- a/parse/src/main/java/com/parse/ParseJSONUtils.java
+++ b/parse/src/main/java/com/parse/ParseJSONUtils.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/parse/src/main/java/com/parse/ParseObject.java
+++ b/parse/src/main/java/com/parse/ParseObject.java
@@ -11,8 +11,8 @@ package com.parse;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
+++ b/parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
@@ -21,8 +21,8 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v4.app.NotificationCompat;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/parse/src/main/java/com/parse/ParseQuery.java
+++ b/parse/src/main/java/com/parse/ParseQuery.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/parse/src/main/java/com/parse/ParseRequest.java
+++ b/parse/src/main/java/com/parse/ParseRequest.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.parse.http.ParseHttpBody;
 import com.parse.http.ParseHttpRequest;

--- a/parse/src/main/java/com/parse/ParseRole.java
+++ b/parse/src/main/java/com/parse/ParseRole.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.regex.Pattern;
 

--- a/parse/src/main/java/com/parse/ParseUser.java
+++ b/parse/src/main/java/com/parse/ParseUser.java
@@ -10,7 +10,7 @@ package com.parse;
 
 import android.os.Bundle;
 import android.os.Parcel;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONObject;
 

--- a/parse/src/main/java/com/parse/PushHistory.java
+++ b/parse/src/main/java/com/parse/PushHistory.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/parse/src/test/java/com/parse/OfflineQueryLogicTest.java
+++ b/parse/src/test/java/com/parse/OfflineQueryLogicTest.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.json.JSONArray;
 import org.json.JSONObject;

--- a/parse/src/test/java/com/parse/ParseQueryTest.java
+++ b/parse/src/test/java/com/parse/ParseQueryTest.java
@@ -8,7 +8,7 @@
  */
 package com.parse;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
This converts the project to SDK 28 and AndroidX, along with updating the OkHttp dependency to the latest version that supports our minSDK.

Next release should likely be a 1.19.0, since the upgrade path might not be compatible if others are not using AndroidX already.