### PR TITLE
Expose useful constants

### DIFF
--- a/parse/src/main/java/com/parse/ParseObject.java
+++ b/parse/src/main/java/com/parse/ParseObject.java
@@ -11,8 +11,6 @@ package com.parse;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -36,6 +34,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import bolts.Capture;
 import bolts.Continuation;
 import bolts.Task;
@@ -67,11 +67,11 @@ public class ParseObject implements Parcelable {
     /*
   REST JSON Keys
   */
-    private static final String KEY_OBJECT_ID = "objectId";
+    public static final String KEY_OBJECT_ID = "objectId";
+    public static final String KEY_CREATED_AT = "createdAt";
+    public static final String KEY_UPDATED_AT = "updatedAt";
     private static final String KEY_CLASS_NAME = "className";
     private static final String KEY_ACL = "ACL";
-    private static final String KEY_CREATED_AT = "createdAt";
-    private static final String KEY_UPDATED_AT = "updatedAt";
     /*
   Internal JSON Keys - Used to store internal data when persisting {@code ParseObject}s locally.
   */

--- a/parse/src/main/java/com/parse/ParseObject.java
+++ b/parse/src/main/java/com/parse/ParseObject.java
@@ -11,6 +11,8 @@ package com.parse;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -34,8 +36,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import bolts.Capture;
 import bolts.Continuation;
 import bolts.Task;


### PR DESCRIPTION
It is interesting to leave these constants exposed because they are heavily used in queries and this change does not cause any problems for the SDK.

Please, let me know if it's all right.