### PR TITLE
Restore Bintray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,16 +7,20 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 plugins {
     id 'com.github.ben-manes.versions' version '0.20.0'
+    id 'digital.wup.android-maven-publish' version '3.6.2'
+    id "com.jfrog.bintray" version "1.8.4"
 }
 
 allprojects {
+    // Allow Jitpack to set the group
+    group = project.hasProperty('group') ? group : DEFAULT_GROUP
+
     repositories {
         google()
         jcenter()

--- a/fcm/build.gradle
+++ b/fcm/build.gradle
@@ -35,4 +35,4 @@ dependencies {
     implementation project(':parse')
 }
 
-apply from: 'https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle'
+apply from: '../gradle/bintray.gradle'

--- a/gcm/build.gradle
+++ b/gcm/build.gradle
@@ -37,4 +37,4 @@ dependencies {
     implementation project(':parse')
 }
 
-apply from: 'https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle'
+apply from: '../gradle/bintray.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
+DEFAULT_GROUP=com.parse

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -1,0 +1,59 @@
+apply plugin: 'digital.wup.android-maven-publish'
+apply plugin: 'com.jfrog.bintray'
+apply from: '../gradle/javadocs.gradle'
+
+task install(dependsOn: publishToMavenLocal) {
+    print "Using new maven publishing plugin"
+}
+
+publishing {
+    publications {
+        mavenAar(MavenPublication) {
+	    from components.android
+            groupId group
+            artifactId project.name
+            artifact sourcesJar
+            artifact javadocJar
+            version project.version
+        }
+
+    }
+}
+
+// Requires apply plugin: 'com.jfrog.bintray'
+
+def ossrhUsername = hasProperty('NEXUS_USERNAME') ? NEXUS_USERNAME : System.getenv('CI_NEXUS_USERNAME')
+def ossrhPassword = hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : System.getenv('CI_NEXUS_PASSWORD')
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ["mavenAar"]
+
+//    dryRun = true
+    publish = false
+    pkg {
+        repo = 'maven'
+        name = 'com.parse:parse-android'
+        userOrg = 'parse'
+        licenses = ['BSD License']
+        vcsUrl = 'https://github.com/parse-community/Parse-SDK-Android'
+        version {
+            name = project.version
+            desc = 'A library that gives you access to the powerful Parse cloud platform from your Android app.'
+            released = new Date()
+            vcsTag = project.version
+
+            // Sonatype username/passwrod must be set for this operation to happen
+/*            mavenCentralSync {
+              sync = true
+              user = ossrhUsername
+              password = ossrhPassword
+              close = '1' // release automatically
+           }*/
+        }
+    }
+}
+
+// End of Bintray plugin
+

--- a/gradle/javadocs.gradle
+++ b/gradle/javadocs.gradle
@@ -1,0 +1,18 @@
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    failOnError  false
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+}
+
+// build a jar with javadoc
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+

--- a/gradle/version-branch.gradle
+++ b/gradle/version-branch.gradle
@@ -1,0 +1,12 @@
+def getWorkingBranch() {
+    // Triple double-quotes for the breaklines
+    def workingBranch = """git --git-dir=${rootDir}/.git
+                               --work-tree=${rootDir}
+                               rev-parse --abbrev-ref HEAD""".execute().text.trim()
+    print "Working branch: " + workingBranch
+    if (workingBranch) {
+        return workingBranch
+    } else {
+        return "default"
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+

--- a/ktx/build.gradle
+++ b/ktx/build.gradle
@@ -33,4 +33,4 @@ dependencies {
     implementation project(':parse')
 }
 
-apply from: 'https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle'
+apply from: '../gradle/bintray.gradle'

--- a/parse/build.gradle
+++ b/parse/build.gradle
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.kt3k.coveralls'
 
+apply from: '../gradle/version-branch.gradle'
+
+version = hasProperty('version') ? version : getWorkingBranch()
+ext.artifact = "parse-android"
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
@@ -8,7 +13,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "1.0"
+        versionName version
         consumerProguardFiles 'release-proguard.pro'
     }
 
@@ -85,4 +90,4 @@ coveralls.jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestReport/jacoco
 
 //endregion
 
-apply from: 'https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle'
+apply from: '../gradle/bintray.gradle'


### PR DESCRIPTION
Adding this PR to get some feedback.  I've had mixed feelings for awhile about requiring people to add jitpack.io to use the Parse SDK.    It definitely saves developer time publishing artifacts but has created a lot of confusion since we still have the old artifacts available.

This change would move to use the new Maven publishing plugin.  Because Jetpack relies on the older Maven plugin and assumes `./gradlew install` to publish the artifacts, I've added a task that maps `./gradlew install` to `./gradlew publishToMavenLocal`.  For releases, we could automate the use of Bintray by bringing back `./gradlew bintrayUpload`.

We previously used artifacts as parse-android, fcm-android, so this will definitely change what we used to do for publishing artifacts on Bintray.

Wanted to get input on supporting Bintray again...
