### PR TITLE
expose client destroy

### DIFF
--- a/parse/src/main/java/com/parse/Parse.java
+++ b/parse/src/main/java/com/parse/Parse.java
@@ -197,10 +197,6 @@ public class Parse {
      * with a new configuration.
      */
     public static void destroy() {
-        destroy();
-    }
-
-    static void destroy() {
         ParseObject.unregisterParseSubclasses();
 
         ParseEventuallyQueue queue;

--- a/parse/src/main/java/com/parse/Parse.java
+++ b/parse/src/main/java/com/parse/Parse.java
@@ -191,6 +191,15 @@ public class Parse {
         }
     }
 
+    /**
+     * Destroys this client and erases its local data store.
+     * Calling this after {@code Parse.initialize} allows you to re-initialize this client
+     * with a new configuration.
+     */
+    public static void destroy() {
+        destroy();
+    }
+
     static void destroy() {
         ParseObject.unregisterParseSubclasses();
 


### PR DESCRIPTION
Exposing `destroy` method to allow to re-initialize client.

There is an existing test case in which this is used.

https://github.com/parse-community/Parse-SDK-Android/blob/0cfc67e9a3bcedc714f0041ee60cafb40ed93520/parse/src/test/java/com/parse/ParseUserTest.java#L1637-L1638