### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The custom `Application` class must be registered in `AndroidManifest.xml`:
 ```xml
 <application
     android:name=".App"
+    android:usesCleartextTraffic="true"
     ...>
     ...
 </application>


### PR DESCRIPTION
Starting with Android 9 (API level 28), cleartext support is disabled by default so we need to set this property to true in order to be able to connect to the server.