### PR TITLE
Add nullability annotations to ParseCloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+## Changelog
+
+### master
+
+- Update OkHttp version to allow for future Android API 30 compilation
+- Compile with Android 29
+- Update Facebook Login dependency to 6.1.0
+- Add nullability annotations to `ParseCloud`
+
+### 1.23.1
+- Correction to OkHttp version thanks to @mtrezza
+
+### 1.23.0
+- Add Google login/signup support
+- Move Facebook and Twitter libraries to be modules within this library
+- Update Facebook login to use AndroidX
+- Add ability to update the server without having to reinitialize the client thanks to @mtrezza
+
+### 1.22.1
+Re-releasing since Jitpack failed. Same as 1.22.0
+
+### 1.22.0
+- Expose client destroy
+- Enhancement to ParseQuery kt operations
+
+### 1.21.0
+- Add coroutines support module
+- Fix bug in save user in batch
+
+### 1.20.0
+- Fix fetchAllIfNeeded and fetchAllIfNeededInBackground limit #939
+- Expose useful constants #930
+- ParseQuery extensions #929
+- Change to non-deprecated methods for FCM #927. If you are using FCM and updating to 1.20.0, be sure to take a look at the FCM README for the updated steps on usage.
+
+### 1.19.0
+- SDK now uses AndroidX and API 28
+- Kotlin Delegates
+- Fix StackOverflowError when merging ParseObject from JSON #896
+
+### 1.18.5
+- Fix for issue #886
+
+### 1.18.4
+- Fix issue with returning { "result": null } in cloud function (deserialized as JSONObject instead of null)
+- Remove deprecated methods in ParseAnalytics and ParsePush
+- Add findAll() method to ParseQuery which iterates and finds all ParseObjects for a query (no limit)
+
+### 1.18.3
+- Add ktx module and dependency, which adds some Kotlin extensions for easier Parse SDK usage.
+
+### 1.18.2
+- More things made public for LiveQuery support
+
+### 1.18.1
+- Make things public for LiveQuery support
+
+### 1.18.0
+- Annotate ParseObject with nullability thanks to @kurtisnelson and @Jawnnypoo
+- Remove deprecated refresh() method from ParseObject
+- Partial string match thanks to @rogerhu
+- Fix delete, save eventually, and findAllPinned issues thanks to @dangtz

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.5.3"
+        classpath "com.android.tools.build:gradle:3.6.0"
         classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id "com.github.ben-manes.versions" version "0.27.0"
+    id "com.github.ben-manes.versions" version "0.28.0"
 }
 
 allprojects {
@@ -28,8 +28,8 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 28
+    compileSdkVersion = 29
 
     minSdkVersion = 14
-    targetSdkVersion = 28
+    targetSdkVersion = 29
 }

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    api "com.facebook.android:facebook-login:5.11.2"
+    api "com.facebook.android:facebook-login:6.1.0"
     implementation project(":parse")
 
     testImplementation "junit:junit:4.13"

--- a/parse/build.gradle
+++ b/parse/build.gradle
@@ -29,7 +29,7 @@ android {
 
 ext {
     // Note: Don't update past 3.12.x, as it sets the minSdk to Android 5.0
-    okhttpVersion = "3.12.8"
+    okhttpVersion = "3.12.9"
 }
 
 dependencies {

--- a/parse/src/main/java/com/parse/ParseCloud.java
+++ b/parse/src/main/java/com/parse/ParseCloud.java
@@ -8,6 +8,8 @@
  */
 package com.parse;
 
+import androidx.annotation.NonNull;
+
 import java.util.List;
 import java.util.Map;
 
@@ -57,8 +59,8 @@ public final class ParseCloud {
      *               be placed in a ParseObject except for ParseObjects themselves.
      * @return A Task that will be resolved when the cloud function has returned.
      */
-    public static <T> Task<T> callFunctionInBackground(final String name,
-                                                       final Map<String, ?> params) {
+    public static <T> Task<T> callFunctionInBackground(@NonNull final String name,
+                                                       @NonNull final Map<String, ?> params) {
         return ParseUser.getCurrentSessionTokenAsync().onSuccessTask(new Continuation<String, Task<T>>() {
             @Override
             public Task<T> then(Task<String> task) {
@@ -79,7 +81,7 @@ public final class ParseCloud {
      * ParseObject.
      * @throws ParseException exception
      */
-    public static <T> T callFunction(String name, Map<String, ?> params) throws ParseException {
+    public static <T> T callFunction(@NonNull String name, @NonNull Map<String, ?> params) throws ParseException {
         return ParseTaskUtils.wait(ParseCloud.<T>callFunctionInBackground(name, params));
     }
 
@@ -91,8 +93,8 @@ public final class ParseCloud {
      *                 be placed in a ParseObject except for ParseObjects themselves.
      * @param callback The callback that will be called when the cloud function has returned.
      */
-    public static <T> void callFunctionInBackground(String name, Map<String, ?> params,
-                                                    FunctionCallback<T> callback) {
+    public static <T> void callFunctionInBackground(@NonNull String name, @NonNull Map<String, ?> params,
+                                                    @NonNull FunctionCallback<T> callback) {
         ParseTaskUtils.callbackOnMainThreadAsync(
                 ParseCloud.<T>callFunctionInBackground(name, params),
                 callback);


### PR DESCRIPTION
This adds `NonNull` annotations to the methods within ParseCloud, since if those values are passed as null, there will be HTTP errors as soon as the cloud function is called. 

This also introduces a CHANGELOG.md file, as other platforms have and updates a few various dependencies.