### PR TITLE
Set to unknown if version name is null

### DIFF
--- a/parse/src/main/java/com/parse/ManifestInfo.java
+++ b/parse/src/main/java/com/parse/ManifestInfo.java
@@ -63,6 +63,12 @@ public class ManifestInfo {
                     PLog.e(TAG, "Couldn't find info about own package", e);
                     versionName = "unknown";
                 }
+                if (versionName == null) {
+                    // Some contexts, such as instrumentation tests can always have this value
+                    // return as null. We will change to "unknown" for this case as well, so that
+                    // an exception isn't thrown for adding a null header later.
+                    versionName = "unknown";
+                }
             }
         }
 


### PR DESCRIPTION
Noted in https://github.com/parse-community/Parse-SDK-Android/issues/1012 we will throw exceptions if the versionName is found to be null when we eventually attach it as a header. Even though this only really occurs in instrumentation tests, it's best if we fix it in the SDK so everyone doesn't have to add a mock workaround. 