### PR TITLE
fix change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Changelog
 
-- FIX/ADD/REMOVE/CHANGE: _Description_ See [#_IssueNumber_](https://github.com/parse-community/Parse-SDK-Android/issues/_IssueNumber_) for details. Thanks to [_Name_](https://github.com/_name_).
-
 ### master
 
 ### 1.24.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,28 @@
 ## Changelog
 
+- FIX/ADD/REMOVE/CHANGE: _Description_ See [#_IssueNumber_](https://github.com/parse-community/Parse-SDK-Android/issues/_IssueNumber_) for details. Thanks to [_Name_](https://github.com/_name_).
+
 ### master
 
-- Update OkHttp version to allow for future Android API 30 compilation
-- Compile with Android 29
-- Update Facebook Login dependency to 6.1.0
-- Add nullability annotations to `ParseCloud`
+### 1.24.2
+- FIX: Fixed naming collission bug due to integration of bolts-tasks module. See [#1028](https://github.com/parse-community/Parse-SDK-Android/issues/1028) for details. Thanks to [Manuel Trezza](https://github.com/mtrezza)
+
+### 1.24.1
+> WARNING:
+>
+> Avoid using this release as it contains a [naming collission bug](https://github.com/parse-community/Parse-SDK-Android/issues/1028) that has been introduced in release `1.24.0` and fixed in release `1.24.2`. The bug causes the project compliation to fail due to duplicate class names for the `bolts-tasks` module when using the Facebook Android SDK or the Parse Android SDK Facebook module.
+
+- Resolves issue around missing bolts-tasks dependency thanks to @rogerhu (#1025)
+
+### 1.24.0
+> WARNING:
+>
+> Avoid using this release as it contains a [naming collission bug](https://github.com/parse-community/Parse-SDK-Android/issues/1028) that has been introduced in release `1.24.0` and fixed in release `1.24.2`. The bug causes the project compliation to fail due to duplicate class names for the `bolts-tasks` module when using the Facebook Android SDK or the Parse Android SDK Facebook module.
+
+- Add bolts-task instead of depending on FB's outdated lib (#1018) thanks to @rogerhu
+- Add nullability to `ParseCloud` (#1008) thanks to @Jawnnypoo
+- Set to unknown name if version name is null (#1014) thanks to @Jawnnypoo
+- Fix signup method name (#1017) thanks to @Jawnnypoo
 
 ### 1.23.1
 - Correction to OkHttp version thanks to @mtrezza


### PR DESCRIPTION
see https://github.com/parse-community/Parse-SDK-Android/issues/1034

I have removed the following entries from `master` section:

- Update OkHttp version to allow for future Android API 30 compilation
 - Compile with Android 29
 - Update Facebook Login dependency to 6.1.0

Not sure what these entries mean and if there was any merge / issue related to them. If they should not be removed and added to a specific release, let me know and I correct that.