### PR TITLE
Add note in docs linking to local datastore issue

### DIFF
--- a/parse/src/main/java/com/parse/Parse.java
+++ b/parse/src/main/java/com/parse/Parse.java
@@ -75,7 +75,8 @@ public class Parse {
      *   }
      * }
      * </pre>
-     *
+     * See <a href="https://github.com/parse-community/Parse-SDK-Android/issues/279">https://github.com/parse-community/Parse-SDK-Android/issues/279</a>
+     * for a discussion on performance of local datastore, and if it is right for your project.
      * @param context The active {@link Context} for your application.
      */
     public static void enableLocalDatastore(Context context) {


### PR DESCRIPTION
It is important for SDK users to understand the drawbacks of using Local Datastore when using the SDK. I think that we need to have a link to the open issue directly in the docs, so there are no surprises for users once they go down the route of using local datastore in their project. https://github.com/parse-community/Parse-SDK-Android/issues/279