### PR TITLE
fix TypeCastException when unlinking google account

### DIFF
--- a/google/src/main/java/com/parse/google/ParseGoogleUtils.kt
+++ b/google/src/main/java/com/parse/google/ParseGoogleUtils.kt
@@ -225,10 +225,10 @@ object ParseGoogleUtils {
                         error = ParseException(error)
                     }
                     if (callback is SaveCallback) {
-                        callback.done(error as ParseException)
+                        callback.done(error as? ParseException)
                     } else if (callback is LogInCallback) {
                         callback.done(
-                                task.result as ParseUser, error as ParseException)
+                                task.result as? ParseUser, error as? ParseException)
                     }
                 } finally {
                     when {


### PR DESCRIPTION
fixes `kotlin.TypeCastException: null cannot be cast to non-null type com.parse.ParseException`

when trying to unlink the `ParseUser` from Google.

The `Task` returns `null` as the `error` when the task was completed successfully.
This is the same behavior as in the [ParseFacebookUtils](https://github.com/parse-community/Parse-SDK-Android/blob/master/facebook/src/main/java/com/parse/facebook/ParseFacebookUtils.java) but was handled incorrectly here.