### PR TITLE
Adding key verification to the getDouble method

### DIFF
--- a/parse/src/main/java/com/parse/ParseObject.java
+++ b/parse/src/main/java/com/parse/ParseObject.java
@@ -3338,7 +3338,7 @@ public class ParseObject implements Parcelable {
      */
     public double getDouble(@NonNull String key) {
         Number number = getNumber(key);
-        if (number == null) {
+        if (number == null || !has(key)) {
             return 0;
         }
         return number.doubleValue();


### PR DESCRIPTION
Hey guys! I don't know if this is the correct way to suggest a change .. but I had a problem recently deciding to make a contribution ..

When trying to give a getDouble in a parse field that could return me undefined, it ended up generating an error in the application, but specifically "Method threw 'java.lang.IllegalStateException' exception." with the following message "ParseObject has no data for 'totalCredits'. Call fetchIfNeeded () to get the data.".

So I am uploading the correction I needed to make in my code.

Function in my local code that was causing problems:

```
var input: Double
         get () = getDouble ("input")
         set (value) = putOrIgnore ("input", value)
```

Function in my local code after corrected:

```
var input: Double
         get () = if (has ("input")) getDouble ("input") else 0.0
         set (value) = putOrIgnore ("input", value)
```

So I decided to add the has function directly in Parse's getDouble method.