### PR TITLE
Updated dependencies + changes accordingly.

### DIFF
--- a/bolts-tasks/build.gradle
+++ b/bolts-tasks/build.gradle
@@ -3,8 +3,8 @@
 // This source code is licensed under the MIT license found in the/
 // LICENSE file in the root directory of this source tree.
 
-apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'java-library'
+apply plugin: 'maven-publish'
 
 configurations {
     provided
@@ -17,20 +17,20 @@ sourceSets {
 }
 
 dependencies {
-    provided 'com.google.android:android:4.1.1.4'
-    testImplementation 'junit:junit:4.12'
+    compileOnly 'com.google.android:android:4.1.1.4'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 
 javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier.set("sources")
     from sourceSets.main.allJava
 }
 
 task javadocJar (type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set("javadoc")
     from javadoc.destinationDir
 }
 
@@ -43,19 +43,40 @@ artifacts {
 
 //region Code Coverage
 
-apply plugin: 'jacoco'
-
-jacoco {
-    toolVersion = '0.7.1.201405082137'
-}
-
-jacocoTestReport {
-    group = "Reporting"
-    description = "Generate Jacoco coverage reports after running tests."
-    reports {
-        xml.enabled true
-        html.enabled true
-    }
-}
+//apply plugin: 'jacoco'
+//
+//jacoco {
+//    toolVersion = '0.8.7'
+//}
+//
+//jacocoTestReport {
+//    group = "Reporting"
+//    description = "Generate Jacoco coverage reports after running tests."
+//    reports {
+//        xml.enabled true
+//        html.enabled true
+//    }
+//}
 
 //endregion
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            // Creates a Maven publication called "moralisPublication".
+            moralisPublication(MavenPublication) {
+                from components.java
+
+                // You can then customize attributes of the publication as shown below.
+                groupId = 'com.github.moralisweb3.sdk.android'
+                artifactId = 'bolts-tasks'
+                version = '0.1'
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,18 @@
 buildscript {
-    ext.kotlin_version = "1.4.10"
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.6.2"
-        classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3"
-        classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
+        classpath "com.android.tools.build:gradle:7.0.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        //classpath "gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.0"
     }
 }
 
 plugins {
-    id "com.github.ben-manes.versions" version "0.28.0"
-}
-
-allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
+    id "com.github.ben-manes.versions" version "0.39.0"
 }
 
 task clean(type: Delete) {
@@ -28,8 +20,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 29
-
-    minSdkVersion = 14
-    targetSdkVersion = 29
+    compileSdkVersion = 31
+    minSdkVersion = 28
+    targetSdkVersion = 31
 }

--- a/coroutines/build.gradle
+++ b/coroutines/build.gradle
@@ -39,4 +39,4 @@ dependencies {
     implementation project(":parse")
 }
 
-apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+//apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -23,9 +23,9 @@ dependencies {
     api "com.facebook.android:facebook-login:6.3.0"
     implementation project(":parse")
 
-    testImplementation "junit:junit:4.13"
+    testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:1.10.19"
-    testImplementation "org.robolectric:robolectric:3.8"
+    testImplementation "org.robolectric:robolectric:4.2.1"
 }
 
-apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+//apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"

--- a/fcm/build.gradle
+++ b/fcm/build.gradle
@@ -28,8 +28,8 @@ android {
 }
 
 dependencies {
-    api "com.google.firebase:firebase-messaging:20.1.5"
+    api "com.google.firebase:firebase-messaging:22.0.0"
     implementation project(":parse")
 }
 
-apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+//apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"

--- a/google/build.gradle
+++ b/google/build.gradle
@@ -22,8 +22,8 @@ android {
 
 dependencies {
     api "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    api "com.google.android.gms:play-services-auth:18.0.0"
+    api "com.google.android.gms:play-services-auth:19.2.0"
     implementation project(":parse")
 }
 
-apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+//apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Sep 21 02:34:31 CEST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11

--- a/ktx/build.gradle
+++ b/ktx/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: "com.android.library"
-
 apply plugin: "kotlin-android"
 
 android {
@@ -37,4 +36,4 @@ dependencies {
     implementation project(":parse")
 }
 
-apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+//apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"

--- a/parse/build.gradle
+++ b/parse/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: "com.android.library"
-apply plugin: "com.github.kt3k.coveralls"
+apply plugin: 'kotlin-android'
+//apply plugin: "com.github.kt3k.coveralls"
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -20,70 +22,91 @@ android {
         abortOnError false
     }
 
-    buildTypes {
+    buildTypes {ja
         debug {
             testCoverageEnabled = true
+        }
+        release {
+            testCoverageEnabled = false
         }
     }
 }
 
 ext {
-    // Note: Don't update past 3.12.x, as it sets the minSdk to Android 5.0
-    okhttpVersion = "3.12.10"
+    okhttpVersion = "4.9.1"
 }
 
 dependencies {
-    api "androidx.annotation:annotation:1.1.0"
-    api "androidx.core:core:1.2.0"
+    api "androidx.annotation:annotation:1.2.0"
+    api "androidx.core:core-ktx:1.6.0"
     api "com.squareup.okhttp3:okhttp:$okhttpVersion"
     api project(':bolts-tasks')
 
-    testImplementation "org.robolectric:robolectric:3.8"
+    testImplementation "org.robolectric:robolectric:4.2.1"
     testImplementation "org.skyscreamer:jsonassert:1.5.0"
     testImplementation "org.mockito:mockito-core:1.10.19"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
+    implementation "androidx.core:core-ktx:1.6.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 //region Code Coverage
 
-apply plugin: "jacoco"
-
-jacoco {
-    toolVersion "0.7.1.201405082137"
-}
-
-task jacocoTestReport(type: JacocoReport, dependsOn: "testDebugUnitTest") {
-    group = "Reporting"
-    description = "Generate Jacoco coverage reports"
-
-    classDirectories = fileTree(
-            dir: "${buildDir}/intermediates/classes/debug",
-            excludes: ['**/R.class',
-                       '**/R$*.class',
-                       '**/*$ViewInjector*.*',
-                       '**/BuildConfig.*',
-                       '**/Manifest*.*']
-    )
-
-    sourceDirectories = files("${buildDir.parent}/src/main/java")
-    additionalSourceDirs = files([
-            "${buildDir}/generated/source/buildConfig/debug",
-            "${buildDir}/generated/source/r/debug"
-    ])
-    executionData = files("${buildDir}/jacoco/testDebugUnitTest.exec")
-
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
-}
+//apply plugin: "jacoco"
+//
+//jacoco {
+//    toolVersion "0.8.7"
+//}
+//
+//task jacocoTestReport(type: JacocoReport, dependsOn: "testDebugUnitTest") {
+//    group = "Reporting"
+//    description = "Generate Jacoco coverage reports"
+//
+//    classDirectories.from = fileTree(
+//            dir: "${buildDir}/intermediates/classes/debug",
+//            excludes: ['**/R.class',
+//                       '**/R$*.class',
+//                       '**/*$ViewInjector*.*',
+//                       '**/BuildConfig.*',
+//                       '**/Manifest*.*']
+//    )
+//
+//    sourceDirectories.from = files("${buildDir.parent}/src/main/java")
+//    additionalSourceDirs.from = files([
+//            "${buildDir}/generated/source/buildConfig/debug",
+//            "${buildDir}/generated/source/r/debug"
+//    ])
+//    executionData.from = files("${buildDir}/jacoco/testDebugUnitTest.exec")
+//
+//    reports {
+//        xml.enabled = true
+//        html.enabled = true
+//    }
+//}
 
 //endregion
 
 //region Coveralls
 
-coveralls.jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
+//coveralls.jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
 
 //endregion
 
-apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+//apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+
+afterEvaluate {
+    publishing {
+        publications {
+            // Creates a Maven publication called “debug”.
+            debug(MavenPublication) {
+                // Applies the component for the debug build variant.
+                from components.release
+
+                groupId = 'com.github.moralisweb3.sdk.android'
+                artifactId = 'parse'
+                version = '0.1'
+            }
+        }
+    }
+}
+

--- a/rxjava/build.gradle
+++ b/rxjava/build.gradle
@@ -34,4 +34,4 @@ dependencies {
     implementation project(":parse")
 }
 
-apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+//apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,10 @@
-include ':parse', ':fcm', ':gcm', ':ktx', ':coroutines', 'rxjava', ':google', ':facebook', ':twitter', ':bolts-tasks'
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url "https://jitpack.io" }
+    }
+}
+include ':parse', ':fcm', ':ktx', ':coroutines', 'rxjava', ':google', ':facebook', ':twitter', ':bolts-tasks'
 

--- a/twitter/build.gradle
+++ b/twitter/build.gradle
@@ -20,13 +20,13 @@ android {
 }
 
 dependencies {
-    api "androidx.appcompat:appcompat:1.1.0"
+    api "androidx.appcompat:appcompat:1.3.1"
     api "oauth.signpost:signpost-core:1.2.1.2"
     api "se.akerfeldt:okhttp-signpost:1.1.0"
     implementation project(":parse")
 
-    testImplementation "junit:junit:4.13"
+    testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:1.10.19"
 }
 
-apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"
+//apply from: "https://raw.githubusercontent.com/Commit451/gradle-android-javadocs/1.1.0/gradle-android-javadocs.gradle"


### PR DESCRIPTION
Important notes:
- minSDK set to API 28 as I prioritize security and adopting new standards over supporting old insecure platforms.
- Old module GCM removed.
- jacoco disabled as using the compiled version over jitpack leads to compilation errors which I could not fix so far.