### PR TITLE
fix: upgrade Facebook SDK

### DIFF
--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -33,3 +33,4 @@ dependencies {
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:3.9.0"
     testImplementation "org.robolectric:robolectric:4.6"
+}


### PR DESCRIPTION
In accordance with #1104 I changed the Facebook for Android SDK version from `6.3.0` to `8.2.0`.
Also, as recommended by RoboElectric, I have updated its version to `4.2.1` to fix the parsing in windows.