### PR TITLE
ci: add API docs workflow

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -3,6 +3,28 @@ on:
   push:
     branches: [ master, release, alpha, beta ]
 jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Generate Javadoc
+        run: ./gradlew javadocRelease
+      - name: Deploy GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          clean: true
+          folder: build/docs/javadoc
+          target-folder: api
+          dry-run: true
   release:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -1,7 +1,9 @@
-name: release
-on:
-  push:
-    branches: [ master ]
+# Trigger this workflow only to manually publish API docs; this should only be used
+# in extraordinary circumstances as this is done automatically as part of the
+# automated release workflow.
+
+name: release-manual-docs
+on: workflow_dispatch
 jobs:
   publish-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
javadoc generation when pushing to `master` branch

related: https://github.com/parse-community/Parse-SDK-Android/issues/1059