### PR TITLE
fix: release Parse Android SDK 2.0.0 not building on jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues?q=is%3Aissue).

### Issue Description
Releases on jitpack are not building correctly.

Related issue: #n/a

### Approach
<!-- Add a description of the approach in this PR. -->

Instruct to build using java 11
See https://jitpack.io/docs/BUILDING/#java-version

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->
