### PR TITLE
fix: failed signup attempt with anonymous ParseUser leaves it in inconsistent state

### DIFF
--- a/parse/src/main/java/com/parse/ParseUser.java
+++ b/parse/src/main/java/com/parse/ParseUser.java
@@ -757,7 +757,7 @@ public class ParseUser extends ParseObject {
 
     /* package */ void putAuthData(String authType, Map<String, String> authData) {
         synchronized (mutex) {
-            Map<String, Map<String, String>> newAuthData = getAuthData();
+            Map<String, Map<String, String>> newAuthData = new HashMap<>(getAuthData());
             newAuthData.put(authType, authData);
             performPut(KEY_AUTH_DATA, newAuthData);
         }
@@ -765,7 +765,7 @@ public class ParseUser extends ParseObject {
 
     private void removeAuthData(String authType) {
         synchronized (mutex) {
-            Map<String, Map<String, String>> newAuthData = getAuthData();
+            Map<String, Map<String, String>> newAuthData = new HashMap<>(getAuthData());
             newAuthData.remove(authType);
             performPut(KEY_AUTH_DATA, newAuthData);
         }

--- a/parse/src/test/java/com/parse/ParseUserTest.java
+++ b/parse/src/test/java/com/parse/ParseUserTest.java
@@ -959,7 +959,7 @@ public class ParseUserTest extends ResetPluginsParseTest {
         ParseTaskUtils.wait(partialMockUser.saveAsync("sessionToken", Task.<Void>forResult(null)));
 
         // Make sure we clean authData
-        assertFalse(partialMockUser.getAuthData().containsKey("facebook"));
+        assertFalse(partialMockUser.getState().authData().containsKey("facebook"));
         // Make sure we save new currentUser
         verify(currentUserController, times(1)).setAsync(partialMockUser);
     }


### PR DESCRIPTION
### Issue Description
The key "authData" contains a `Map` of authentication related data. Because unfortunately `estimatedData` is a shallow copy of `state`, the object pointed to by `state["authData"]` and `estimatedData["authData"]` is the same object. Modifying the data in this map directly prevents us from being able to call `revert()` to revert the data back to the server state.

This is impotant e.g. when trying to revert the user after converting it from anonymous to registered fails, where anonymity has been stripped and there is no way to get it back. 

Related issue: #401

### Approach
This would just create another (shallow) copy of "authData", which in this case would be fine, because we are only modifying the first layer. By replacing the value of the map with a new map we ensure that the values in `state` and `estimatedData` are different and that `revert()` works.
