### PR TITLE
fix: missing pending intents mutability for Android 12+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,10 +63,10 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 30
+    compileSdkVersion = 31
 
     minSdkVersion = 16
-    targetSdkVersion = 30
+    targetSdkVersion = 31
 }
 
 task createSpotlessPreCommitHook() {

--- a/build.gradle
+++ b/build.gradle
@@ -63,10 +63,10 @@ allprojects {
 }
 
 ext {
-    compileSdkVersion = 31
+    compileSdkVersion = 30
 
     minSdkVersion = 16
-    targetSdkVersion = 31
+    targetSdkVersion = 30
 }
 
 task createSpotlessPreCommitHook() {

--- a/parse/build.gradle
+++ b/parse/build.gradle
@@ -81,7 +81,7 @@ tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
     jacoco.excludes = ['jdk.internal.*']
     testLogging {
-        events "passed", "skipped", "failed", "standardOut", "standardError"
+        events "failed"
     }
 }
 

--- a/parse/src/main/java/com/parse/ParseCommandCache.java
+++ b/parse/src/main/java/com/parse/ParseCommandCache.java
@@ -144,7 +144,9 @@ class ParseCommandCache extends ParseEventuallyQueue {
     public void onDestroy() {
         // TODO (grantland): pause #6484855
 
-        notifier.removeListener(listener);
+        if (notifier != null) {
+            notifier.removeListener(listener);
+        }
     }
 
     // Set the maximum number of times to retry before assuming disconnection.

--- a/parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
+++ b/parse/src/main/java/com/parse/ParsePushBroadcastReceiver.java
@@ -426,18 +426,17 @@ public class ParsePushBroadcastReceiver extends BroadcastReceiver {
 
         Intent deleteIntent = getDeleteIntent(extras, packageName);
 
+        int pendingIntentFlags =
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+                        ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+                        : PendingIntent.FLAG_UPDATE_CURRENT;
+
         PendingIntent pContentIntent =
                 PendingIntent.getBroadcast(
-                        context,
-                        contentIntentRequestCode,
-                        contentIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, contentIntentRequestCode, contentIntent, pendingIntentFlags);
         PendingIntent pDeleteIntent =
                 PendingIntent.getBroadcast(
-                        context,
-                        deleteIntentRequestCode,
-                        deleteIntent,
-                        PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, deleteIntentRequestCode, deleteIntent, pendingIntentFlags);
 
         String channelId = null;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/parse/src/test/java/com/parse/ParsePushBroadcastReceiverTest.java
+++ b/parse/src/test/java/com/parse/ParsePushBroadcastReceiverTest.java
@@ -1,0 +1,165 @@
+package com.parse;
+
+import static androidx.core.app.NotificationCompat.EXTRA_TEXT;
+import static androidx.core.app.NotificationCompat.EXTRA_TITLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Intent;
+import androidx.core.app.NotificationCompat;
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class ParsePushBroadcastReceiverTest extends ResetPluginsParseTest {
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        Parse.Configuration configuration =
+                new Parse.Configuration.Builder(RuntimeEnvironment.application)
+                        .applicationId(BuildConfig.LIBRARY_PACKAGE_NAME)
+                        .server("https://api.parse.com/1")
+                        .build();
+
+        ParsePlugins plugins = mock(ParsePlugins.class);
+        when(plugins.configuration()).thenReturn(configuration);
+        when(plugins.applicationContext()).thenReturn(RuntimeEnvironment.application);
+        Parse.initialize(configuration, plugins);
+    }
+
+    @Test
+    public void testBuildNotification() {
+        final ParsePushBroadcastReceiver broadcastReceiver = new ParsePushBroadcastReceiver();
+        final Map<String, String> map = new HashMap();
+        map.put("alert", "alert");
+        map.put("title", "title");
+
+        final String notificationPayload = new JSONObject(map).toString();
+
+        final Intent intent = new Intent();
+        intent.putExtra(ParsePushBroadcastReceiver.KEY_PUSH_DATA, notificationPayload);
+
+        final NotificationCompat.Builder notification =
+                broadcastReceiver.getNotification(
+                        RuntimeEnvironment.getApplication().getApplicationContext(), intent);
+
+        assertNotNull(notification);
+    }
+
+    @Test
+    public void testBuildNotificationReturnsNullOnInvalidPayload() {
+        final ParsePushBroadcastReceiver broadcastReceiver = new ParsePushBroadcastReceiver();
+        final Intent intent = new Intent();
+        intent.putExtra(ParsePushBroadcastReceiver.KEY_PUSH_DATA, "{\"json\": broken json}");
+
+        final NotificationCompat.Builder notification =
+                broadcastReceiver.getNotification(
+                        RuntimeEnvironment.getApplication().getApplicationContext(), intent);
+
+        assertNull(notification);
+    }
+
+    @Test
+    public void testBuildNotificationReturnsNullOnMissingTitleAndAlert() {
+        final ParsePushBroadcastReceiver broadcastReceiver = new ParsePushBroadcastReceiver();
+        final Map<String, String> map = new HashMap();
+
+        final String notificationPayload = new JSONObject(map).toString();
+
+        final Intent intent = new Intent();
+        intent.putExtra(ParsePushBroadcastReceiver.KEY_PUSH_DATA, notificationPayload);
+
+        final NotificationCompat.Builder notification =
+                broadcastReceiver.getNotification(
+                        RuntimeEnvironment.getApplication().getApplicationContext(), intent);
+
+        assertNull(notification);
+    }
+
+    @Test
+    public void testNotificationBuilderWhenAlertNotProvidedSetFallback() {
+        final ParsePushBroadcastReceiver broadcastReceiver = new ParsePushBroadcastReceiver();
+        final Map<String, String> map = new HashMap();
+        map.put("title", "title");
+
+        final String notificationPayload = new JSONObject(map).toString();
+
+        final Intent intent = new Intent();
+        intent.putExtra(ParsePushBroadcastReceiver.KEY_PUSH_DATA, notificationPayload);
+
+        final NotificationCompat.Builder notification =
+                broadcastReceiver.getNotification(
+                        RuntimeEnvironment.getApplication().getApplicationContext(), intent);
+
+        assertNotNull(notification);
+        assertEquals("Notification received.", notification.build().extras.getString(EXTRA_TEXT));
+    }
+
+    @Test
+    public void testNotificationBuilderWhenAlertIsSetWhenProvided() {
+        final ParsePushBroadcastReceiver broadcastReceiver = new ParsePushBroadcastReceiver();
+        final Map<String, String> map = new HashMap();
+        map.put("alert", "This is an alert");
+
+        final String notificationPayload = new JSONObject(map).toString();
+
+        final Intent intent = new Intent();
+        intent.putExtra(ParsePushBroadcastReceiver.KEY_PUSH_DATA, notificationPayload);
+
+        final NotificationCompat.Builder notification =
+                broadcastReceiver.getNotification(
+                        RuntimeEnvironment.getApplication().getApplicationContext(), intent);
+
+        assertNotNull(notification);
+        assertEquals("This is an alert", notification.build().extras.getString(EXTRA_TEXT));
+    }
+
+    @Test
+    public void testNotificationBuilderWhenTitleNotProvidedSetFallback() {
+        final ParsePushBroadcastReceiver broadcastReceiver = new ParsePushBroadcastReceiver();
+        final Map<String, String> map = new HashMap();
+        map.put("alert", "alert");
+
+        final String notificationPayload = new JSONObject(map).toString();
+
+        final Intent intent = new Intent();
+        intent.putExtra(ParsePushBroadcastReceiver.KEY_PUSH_DATA, notificationPayload);
+
+        final NotificationCompat.Builder notification =
+                broadcastReceiver.getNotification(
+                        RuntimeEnvironment.getApplication().getApplicationContext(), intent);
+
+        assertNotNull(notification);
+        assertEquals("com.parse.test", notification.build().extras.getString(EXTRA_TITLE));
+    }
+
+    @Test
+    public void testNotificationBuilderWhenTitleIsSetWhenProvided() {
+        final ParsePushBroadcastReceiver broadcastReceiver = new ParsePushBroadcastReceiver();
+        final Map<String, String> map = new HashMap();
+        map.put("title", "Application name");
+
+        final String notificationPayload = new JSONObject(map).toString();
+
+        final Intent intent = new Intent();
+        intent.putExtra(ParsePushBroadcastReceiver.KEY_PUSH_DATA, notificationPayload);
+
+        final NotificationCompat.Builder notification =
+                broadcastReceiver.getNotification(
+                        RuntimeEnvironment.getApplication().getApplicationContext(), intent);
+
+        assertNotNull(notification);
+        assertEquals("Application name", notification.build().extras.getString(EXTRA_TITLE));
+    }
+}

--- a/parse/src/test/java/com/parse/ParsePushBroadcastReceiverTest.java
+++ b/parse/src/test/java/com/parse/ParsePushBroadcastReceiverTest.java
@@ -13,6 +13,7 @@ import androidx.core.app.NotificationCompat;
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,6 +37,14 @@ public class ParsePushBroadcastReceiverTest extends ResetPluginsParseTest {
         when(plugins.configuration()).thenReturn(configuration);
         when(plugins.applicationContext()).thenReturn(RuntimeEnvironment.application);
         Parse.initialize(configuration, plugins);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ParseCorePlugins.getInstance().reset();
+        ParsePlugins.reset();
+        Parse.destroy();
     }
 
     @Test


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues?q=is%3Aissue).

### Issue Description

Pending intents mutability

If your app targets Android 12, you must specify the mutability of each PendingIntent object that your app creates. This additional requirement improves your app's security.

https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

Related issue: #1137
Closes #1137 

### Approach
<!-- Add a description of the approach in this PR. -->

Freeze version of the compile and target to the newest version 31 and on Android 12 versions set PendingIntent immutability flags when receiving Parse notifications.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] ~Add tests~
- [ ] ~Add changes to documentation (guides, repository pages, in-code descriptions)~
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
