### PR TITLE
docs: update documentation for setLimit method

### DIFF
--- a/parse/src/main/java/com/parse/ParseQuery.java
+++ b/parse/src/main/java/com/parse/ParseQuery.java
@@ -1256,8 +1256,7 @@ public class ParseQuery<T extends ParseObject> {
     /**
      * Controls the maximum number of results that are returned.
      *
-     * <p>Setting a negative limit denotes retrieval without a limit. The default limit is {@code
-     * 100}, with a maximum of {@code 1000} results being returned at a time.
+     * <p>The default limit is {@code 100}, there is no maximum limit.
      *
      * @param newLimit The new limit.
      * @return this, so you can chain this call.


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [ ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
As I was using setLimit I realized that setting a negative limit does not work anymore as it defaults to 100 anyways.
I looked it up in the web documentation and found this:

> You can limit the number of results with setLimit. By default, results are limited to 100. In the old Parse hosted backend, the maximum limit was 1,000, but Parse Server removed that constraint

So I quickly updated the documentation, I hope it fits.

### Approach
Well, ...

### TODOs before merging
- [ ] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)