### PR TITLE
fix: exception on concurrent download of `ParseFile` from multiple threads

### DIFF
--- a/parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -361,9 +361,7 @@ public class ParseFileControllerTest {
         File root = new File(temporaryFolder.getRoot(), "cache");
         assertFalse(root.exists());
         ParseFileController controller = new ParseFileController(null, root).fileClient(fileClient);
-
         ParseFile.State state = new ParseFile.State.Builder().name("file_name").url("url").build();
-
         CountDownLatch countDownLatch = new CountDownLatch(2);
         AtomicReference<File> file1Ref = new AtomicReference<>();
         AtomicReference<File> file2Ref = new AtomicReference<>();

--- a/parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -392,14 +392,11 @@ public class ParseFileControllerTest {
 
         File result1 = file1Ref.get();
         File result2 = file2Ref.get();
-
-
+        
         assertTrue(result1.exists());
         assertEquals("hello", ParseFileUtils.readFileToString(result1, "UTF-8"));
-
         assertTrue(result2.exists());
         assertEquals("hello", ParseFileUtils.readFileToString(result2, "UTF-8"));
-
         verify(fileClient, times(1)).execute(any(ParseHttpRequest.class));
         assertFalse(controller.getTempFile(state).exists());
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [ x ] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [ x ] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #1155

### Approach
<!-- Add a description of the approach in this PR. -->

This PR simplifies the logic of `fetchAsync` method and then adds a concurrent code that blocks the second (and further) calling threads until the first thread finishes the download of ParseFile (or fails to do so).

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ x ] Add tests
- [ x ] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
