### PR TITLE
fix: exception on concurrent download of `ParseFile` from multiple threads

### DIFF
--- a/parse/src/main/java/com/parse/ParseFileController.java
+++ b/parse/src/main/java/com/parse/ParseFileController.java
@@ -25,7 +25,6 @@ class ParseFileController {
     private final File cachePath;
     private final List<String> currentlyDownloadedFilesNames = new ArrayList<>();
 
-
     private ParseHttpClient fileClient;
 
     public ParseFileController(ParseHttpClient restClient, File cachePath) {
@@ -172,79 +171,80 @@ class ParseFileController {
         if (cancellationToken != null && cancellationToken.isCancelled()) {
             return Task.cancelled();
         }
-        return Task.call(() -> {
-            final File cacheFile = getCacheFile(state);
+        return Task.call(
+                () -> {
+                    final File cacheFile = getCacheFile(state);
 
-            synchronized (lock) {
-                if (currentlyDownloadedFilesNames.contains(state.name())) {
-                    while (currentlyDownloadedFilesNames.contains(state.name())) {
-                        lock.wait();
+                    synchronized (lock) {
+                        if (currentlyDownloadedFilesNames.contains(state.name())) {
+                            while (currentlyDownloadedFilesNames.contains(state.name())) {
+                                lock.wait();
+                            }
+                        }
+
+                        if (cacheFile.exists()) {
+                            return cacheFile;
+                        } else {
+                            currentlyDownloadedFilesNames.add(state.name());
+                        }
                     }
-                }
 
-                if (cacheFile.exists()) {
-                    return cacheFile;
-                } else {
-                    currentlyDownloadedFilesNames.add(state.name());
-                }
-            }
+                    try {
+                        if (cancellationToken != null && cancellationToken.isCancelled()) {
+                            throw new CancellationException();
+                        }
 
-            try {
-                if (cancellationToken != null && cancellationToken.isCancelled()) {
-                    throw new CancellationException();
-                }
+                        // Generate the temp file path for caching ParseFile content based on
+                        // ParseFile's url
+                        // The reason we do not write to the cacheFile directly is because there
+                        // is no way we can
+                        // verify if a cacheFile is complete or not. If download is interrupted
+                        // in the middle, next
+                        // time when we download the ParseFile, since cacheFile has already
+                        // existed, we will return
+                        // this incomplete cacheFile
+                        final File tempFile = getTempFile(state);
 
-                // Generate the temp file path for caching ParseFile content based on
-                // ParseFile's url
-                // The reason we do not write to the cacheFile directly is because there
-                // is no way we can
-                // verify if a cacheFile is complete or not. If download is interrupted
-                // in the middle, next
-                // time when we download the ParseFile, since cacheFile has already
-                // existed, we will return
-                // this incomplete cacheFile
-                final File tempFile = getTempFile(state);
+                        // network
+                        final ParseFileRequest request =
+                                new ParseFileRequest(
+                                        ParseHttpRequest.Method.GET, state.url(), tempFile);
 
-                // network
-                final ParseFileRequest request =
-                    new ParseFileRequest(
-                        ParseHttpRequest.Method.GET, state.url(), tempFile);
+                        // We do not need to delete the temp file since we always try to
+                        // overwrite it
+                        Task<Void> downloadTask =
+                                request.executeAsync(
+                                        fileClient(),
+                                        null,
+                                        downloadProgressCallback,
+                                        cancellationToken);
+                        ParseTaskUtils.wait(downloadTask);
 
-                // We do not need to delete the temp file since we always try to
-                // overwrite it
-                Task<Void> downloadTask = request.executeAsync(
-                    fileClient(),
-                    null,
-                    downloadProgressCallback,
-                    cancellationToken
-                );
-                ParseTaskUtils.wait(downloadTask);
+                        // If the top-level task was cancelled, don't
+                        // actually set the data -- just move on.
+                        if (cancellationToken != null && cancellationToken.isCancelled()) {
+                            throw new CancellationException();
+                        }
+                        if (downloadTask.isFaulted()) {
+                            ParseFileUtils.deleteQuietly(tempFile);
+                            throw new RuntimeException(downloadTask.getError());
+                        }
 
-                // If the top-level task was cancelled, don't
-                // actually set the data -- just move on.
-                if (cancellationToken != null && cancellationToken.isCancelled()) {
-                    throw new CancellationException();
-                }
-                if (downloadTask.isFaulted()) {
-                    ParseFileUtils.deleteQuietly(tempFile);
-                    throw new RuntimeException(downloadTask.getError());
-                }
-
-                // Since we give the cacheFile pointer to
-                // developers, it is not safe to guarantee
-                // cacheFile always does not exist here, so it is
-                // better to delete it manually,
-                // otherwise moveFile may throw an exception.
-                ParseFileUtils.deleteQuietly(cacheFile);
-                ParseFileUtils.moveFile(tempFile, cacheFile);
-                return cacheFile;
-            } finally {
-                synchronized (lock) {
-                    currentlyDownloadedFilesNames.remove(state.name());
-                    lock.notifyAll();
-                }
-            }
-
-        }, ParseExecutors.io());
+                        // Since we give the cacheFile pointer to
+                        // developers, it is not safe to guarantee
+                        // cacheFile always does not exist here, so it is
+                        // better to delete it manually,
+                        // otherwise moveFile may throw an exception.
+                        ParseFileUtils.deleteQuietly(cacheFile);
+                        ParseFileUtils.moveFile(tempFile, cacheFile);
+                        return cacheFile;
+                    } finally {
+                        synchronized (lock) {
+                            currentlyDownloadedFilesNames.remove(state.name());
+                            lock.notifyAll();
+                        }
+                    }
+                },
+                ParseExecutors.io());
     }
 }

--- a/parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -361,9 +361,7 @@ public class ParseFileControllerTest {
         File root = new File(temporaryFolder.getRoot(), "cache");
         assertFalse(root.exists());
         ParseFileController controller = new ParseFileController(null, root).fileClient(fileClient);
-
         ParseFile.State state = new ParseFile.State.Builder().name("file_name").url("url").build();
-
         CountDownLatch countDownLatch = new CountDownLatch(2);
         AtomicReference<File> file1Ref = new AtomicReference<>();
         AtomicReference<File> file2Ref = new AtomicReference<>();

--- a/parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -392,14 +392,11 @@ public class ParseFileControllerTest {
 
         File result1 = file1Ref.get();
         File result2 = file2Ref.get();
-
-
+        
         assertTrue(result1.exists());
         assertEquals("hello", ParseFileUtils.readFileToString(result1, "UTF-8"));
-
         assertTrue(result2.exists());
         assertEquals("hello", ParseFileUtils.readFileToString(result2, "UTF-8"));
-
         verify(fileClient, times(1)).execute(any(ParseHttpRequest.class));
         assertFalse(controller.getTempFile(state).exists());
     }

--- a/parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -30,7 +30,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -344,16 +343,15 @@ public class ParseFileControllerTest {
         assertFalse(controller.getTempFile(state).exists());
     }
 
-
     @Test
     public void testFetchAsyncConcurrentCallsSuccess() throws Exception {
         byte[] data = "hello".getBytes();
         ParseHttpResponse mockResponse =
-            new ParseHttpResponse.Builder()
-                .setStatusCode(200)
-                .setTotalSize((long) data.length)
-                .setContent(new ByteArrayInputStream(data))
-                .build();
+                new ParseHttpResponse.Builder()
+                        .setStatusCode(200)
+                        .setTotalSize((long) data.length)
+                        .setContent(new ByteArrayInputStream(data))
+                        .build();
 
         ParseHttpClient fileClient = mock(ParseHttpClient.class);
         when(fileClient.execute(any(ParseHttpRequest.class))).thenReturn(mockResponse);
@@ -366,31 +364,39 @@ public class ParseFileControllerTest {
         AtomicReference<File> file1Ref = new AtomicReference<>();
         AtomicReference<File> file2Ref = new AtomicReference<>();
 
-        new Thread(() -> {
-            try {
-                file1Ref.set(ParseTaskUtils.wait(controller.fetchAsync(state, null, null, null)));
-            } catch (ParseException e) {
-                throw new RuntimeException(e);
-            } finally {
-                countDownLatch.countDown();
-            }
-        }).start();
+        new Thread(
+                        () -> {
+                            try {
+                                file1Ref.set(
+                                        ParseTaskUtils.wait(
+                                                controller.fetchAsync(state, null, null, null)));
+                            } catch (ParseException e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                countDownLatch.countDown();
+                            }
+                        })
+                .start();
 
-        new Thread(() -> {
-            try {
-                file2Ref.set(ParseTaskUtils.wait(controller.fetchAsync(state, null, null, null)));
-            } catch (ParseException e) {
-                throw new RuntimeException(e);
-            } finally {
-                countDownLatch.countDown();
-            }
-        }).start();
+        new Thread(
+                        () -> {
+                            try {
+                                file2Ref.set(
+                                        ParseTaskUtils.wait(
+                                                controller.fetchAsync(state, null, null, null)));
+                            } catch (ParseException e) {
+                                throw new RuntimeException(e);
+                            } finally {
+                                countDownLatch.countDown();
+                            }
+                        })
+                .start();
 
         countDownLatch.await();
 
         File result1 = file1Ref.get();
         File result2 = file2Ref.get();
-        
+
         assertTrue(result1.exists());
         assertEquals("hello", ParseFileUtils.readFileToString(result1, "UTF-8"));
         assertTrue(result2.exists());

--- a/parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -30,6 +30,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -343,15 +344,16 @@ public class ParseFileControllerTest {
         assertFalse(controller.getTempFile(state).exists());
     }
 
+
     @Test
     public void testFetchAsyncConcurrentCallsSuccess() throws Exception {
         byte[] data = "hello".getBytes();
         ParseHttpResponse mockResponse =
-                new ParseHttpResponse.Builder()
-                        .setStatusCode(200)
-                        .setTotalSize((long) data.length)
-                        .setContent(new ByteArrayInputStream(data))
-                        .build();
+            new ParseHttpResponse.Builder()
+                .setStatusCode(200)
+                .setTotalSize((long) data.length)
+                .setContent(new ByteArrayInputStream(data))
+                .build();
 
         ParseHttpClient fileClient = mock(ParseHttpClient.class);
         when(fileClient.execute(any(ParseHttpRequest.class))).thenReturn(mockResponse);
@@ -364,39 +366,31 @@ public class ParseFileControllerTest {
         AtomicReference<File> file1Ref = new AtomicReference<>();
         AtomicReference<File> file2Ref = new AtomicReference<>();
 
-        new Thread(
-                        () -> {
-                            try {
-                                file1Ref.set(
-                                        ParseTaskUtils.wait(
-                                                controller.fetchAsync(state, null, null, null)));
-                            } catch (ParseException e) {
-                                throw new RuntimeException(e);
-                            } finally {
-                                countDownLatch.countDown();
-                            }
-                        })
-                .start();
+        new Thread(() -> {
+            try {
+                file1Ref.set(ParseTaskUtils.wait(controller.fetchAsync(state, null, null, null)));
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            } finally {
+                countDownLatch.countDown();
+            }
+        }).start();
 
-        new Thread(
-                        () -> {
-                            try {
-                                file2Ref.set(
-                                        ParseTaskUtils.wait(
-                                                controller.fetchAsync(state, null, null, null)));
-                            } catch (ParseException e) {
-                                throw new RuntimeException(e);
-                            } finally {
-                                countDownLatch.countDown();
-                            }
-                        })
-                .start();
+        new Thread(() -> {
+            try {
+                file2Ref.set(ParseTaskUtils.wait(controller.fetchAsync(state, null, null, null)));
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            } finally {
+                countDownLatch.countDown();
+            }
+        }).start();
 
         countDownLatch.await();
 
         File result1 = file1Ref.get();
         File result2 = file2Ref.get();
-
+        
         assertTrue(result1.exists());
         assertEquals("hello", ParseFileUtils.readFileToString(result1, "UTF-8"));
         assertTrue(result2.exists());


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Related issue: #1179 

### Approach

This PR simplifies the logic of fetchAsync method and then adds a concurrent code that blocks the second (and further) calling threads until the first thread finishes the download of ParseFile (or fails to do so).

Updates: Fixed CI failing issue on PR #1179 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
- [x] A changelog entry is created automatically using the pull request title (do not manually add a changelog entry)
