### PR TITLE
feat: Add support for Facebook SDK 15.x

### DIFF
--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    api "com.facebook.android:facebook-login:[13.2.0, 14.0["
+    api "com.facebook.android:facebook-login:[13.2.0, 14.1.1]"
     implementation project(":parse")
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    api "com.facebook.android:facebook-login:[13.2.0, 16.0.0]"
+    api "com.facebook.android:facebook-login:[13.2.0, 17.0.0["
     implementation project(":parse")
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"

--- a/facebook/build.gradle
+++ b/facebook/build.gradle
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-    api "com.facebook.android:facebook-login:[13.2.0, 14.1.1]"
+    api "com.facebook.android:facebook-login:[13.2.0, 16.0.0]"
     implementation project(":parse")
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues/1187).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Use more recent version of Facebook SDK to fix an issue where the login flow is broken if the Facebook app is not installed on the device. See Facebook SDK v14.1.1 changelog: https://github.com/facebook/facebook-android-sdk/blob/main/CHANGELOG.md#1411


Closes: #1187 

### Approach

Allow to use Facebook SDK dependency v14.1.1

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

Nothing necessary
