### PR TITLE
feat: Add idempotency feature to detect duplicate requests due to network conditions

### DIFF
--- a/parse/src/main/java/com/parse/ParseException.java
+++ b/parse/src/main/java/com/parse/ParseException.java
@@ -102,6 +102,8 @@ public class ParseException extends Exception {
     public static final int FILE_DELETE_ERROR = 153;
     /** Error code indicating that the application has exceeded its request limit. */
     public static final int REQUEST_LIMIT_EXCEEDED = 155;
+    /** Error code indicating that the request was a duplicate and has been discarded due to idempotency rules. */
+    public static final int DUPLICATE_REQUEST = 159;
     /** Error code indicating that the provided event name is invalid. */
     public static final int INVALID_EVENT_NAME = 160;
     /** Error code indicating that the username is missing or empty. */

--- a/parse/src/main/java/com/parse/ParseRESTCommand.java
+++ b/parse/src/main/java/com/parse/ParseRESTCommand.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.UUID;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -37,8 +39,8 @@ class ParseRESTCommand extends ParseRequest<JSONObject> {
     /* package */ static final String HEADER_INSTALLATION_ID = "X-Parse-Installation-Id";
     /* package */ static final String HEADER_REQUEST_ID = "X-Parse-Request-Id";
     /* package */ static final String USER_AGENT = "User-Agent";
-    /* package */ static final String HEADER_SESSION_TOKEN = "X-Parse-Session-Token";
-    /* package */ static final String HEADER_MASTER_KEY = "X-Parse-Master-Key";
+    private static final String HEADER_SESSION_TOKEN = "X-Parse-Session-Token";
+    private static final String HEADER_MASTER_KEY = "X-Parse-Master-Key";
     private static final String PARAMETER_METHOD_OVERRIDE = "_method";
 
     // Set via Parse.initialize(Configuration)
@@ -50,6 +52,7 @@ class ParseRESTCommand extends ParseRequest<JSONObject> {
     /* package */ String httpPath;
     private String installationId;
     private String operationSetUUID;
+    private final String requestId = UUID.randomUUID().toString();
     private String localId;
 
     public ParseRESTCommand(
@@ -216,20 +219,7 @@ class ParseRESTCommand extends ParseRequest<JSONObject> {
         if (masterKey != null) {
             requestBuilder.addHeader(HEADER_MASTER_KEY, masterKey);
         }
-        try {
-            JSONObject jsonObject = jsonParameters != null ? new JSONObject(jsonParameters.toString()) : new JSONObject();
-            // using header names so we don't override a parameter with the same key name,
-            // using all headers to insure the requestId generated doesn't conflict with the rest of the users
-            if (installationId != null)
-                jsonObject.put(HEADER_INSTALLATION_ID, installationId);
-            if (sessionToken != null)
-                jsonObject.put(HEADER_SESSION_TOKEN, sessionToken);
-            if (masterKey != null)
-                jsonObject.put(HEADER_MASTER_KEY, masterKey);
-            requestBuilder.addHeader(HEADER_REQUEST_ID, ParseDigestUtils.md5(toDeterministicString(jsonObject)));
-        } catch (JSONException e) {
-            throw new RuntimeException(e.getMessage());
-        }
+        requestBuilder.addHeader(HEADER_REQUEST_ID, requestId);
     }
 
     @Override

--- a/parse/src/main/java/com/parse/ParseRESTCommand.java
+++ b/parse/src/main/java/com/parse/ParseRESTCommand.java
@@ -35,9 +35,10 @@ class ParseRESTCommand extends ParseRequest<JSONObject> {
     /* package */ static final String HEADER_OS_VERSION = "X-Parse-OS-Version";
 
     /* package */ static final String HEADER_INSTALLATION_ID = "X-Parse-Installation-Id";
+    /* package */ static final String HEADER_REQUEST_ID = "X-Parse-Request-Id";
     /* package */ static final String USER_AGENT = "User-Agent";
-    private static final String HEADER_SESSION_TOKEN = "X-Parse-Session-Token";
-    private static final String HEADER_MASTER_KEY = "X-Parse-Master-Key";
+    /* package */ static final String HEADER_SESSION_TOKEN = "X-Parse-Session-Token";
+    /* package */ static final String HEADER_MASTER_KEY = "X-Parse-Master-Key";
     private static final String PARAMETER_METHOD_OVERRIDE = "_method";
 
     // Set via Parse.initialize(Configuration)
@@ -214,6 +215,20 @@ class ParseRESTCommand extends ParseRequest<JSONObject> {
         }
         if (masterKey != null) {
             requestBuilder.addHeader(HEADER_MASTER_KEY, masterKey);
+        }
+        try {
+            JSONObject jsonObject = jsonParameters != null ? new JSONObject(jsonParameters.toString()) : new JSONObject();
+            // using header names so we don't override a parameter with the same key name,
+            // using all headers to insure the requestId generated doesn't conflict with the rest of the users
+            if (installationId != null)
+                jsonObject.put(HEADER_INSTALLATION_ID, installationId);
+            if (sessionToken != null)
+                jsonObject.put(HEADER_SESSION_TOKEN, sessionToken);
+            if (masterKey != null)
+                jsonObject.put(HEADER_MASTER_KEY, masterKey);
+            requestBuilder.addHeader(HEADER_REQUEST_ID, ParseDigestUtils.md5(toDeterministicString(jsonObject)));
+        } catch (JSONException e) {
+            throw new RuntimeException(e.getMessage());
         }
     }
 

--- a/parse/src/test/java/com/parse/ParseRESTUserCommandTest.java
+++ b/parse/src/test/java/com/parse/ParseRESTUserCommandTest.java
@@ -19,9 +19,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
-
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
@@ -29,7 +26,6 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 
 public class ParseRESTUserCommandTest {
-    private static final String ALLOWED_CHARACTERS = "0123456789qwertyuiopasdfghjklzxcvbnm";
 
     @Before
     public void setUp() throws MalformedURLException {
@@ -59,7 +55,7 @@ public class ParseRESTUserCommandTest {
     @Test
     public void testLogInUserCommand() throws Exception {
         ParseRESTUserCommand command =
-                ParseRESTUserCommand.logInUserCommand("userName", "password", true);
+            ParseRESTUserCommand.logInUserCommand("userName", "password", true);
 
         assertEquals("login", command.httpPath);
         assertEquals(ParseHttpRequest.Method.GET, command.method);
@@ -72,7 +68,7 @@ public class ParseRESTUserCommandTest {
     @Test
     public void testResetPasswordResetCommand() throws Exception {
         ParseRESTUserCommand command =
-                ParseRESTUserCommand.resetPasswordResetCommand("test@parse.com");
+            ParseRESTUserCommand.resetPasswordResetCommand("test@parse.com");
 
         assertEquals("requestPasswordReset", command.httpPath);
         assertEquals(ParseHttpRequest.Method.POST, command.method);
@@ -86,7 +82,7 @@ public class ParseRESTUserCommandTest {
         JSONObject parameters = new JSONObject();
         parameters.put("key", "value");
         ParseRESTUserCommand command =
-                ParseRESTUserCommand.signUpUserCommand(parameters, "sessionToken", true);
+            ParseRESTUserCommand.signUpUserCommand(parameters, "sessionToken", true);
 
         assertEquals("users", command.httpPath);
         assertEquals(ParseHttpRequest.Method.POST, command.method);
@@ -100,7 +96,7 @@ public class ParseRESTUserCommandTest {
         JSONObject parameters = new JSONObject();
         parameters.put("key", "value");
         ParseRESTUserCommand command =
-                ParseRESTUserCommand.serviceLogInUserCommand(parameters, "sessionToken", true);
+            ParseRESTUserCommand.serviceLogInUserCommand(parameters, "sessionToken", true);
 
         assertEquals("users", command.httpPath);
         assertEquals(ParseHttpRequest.Method.POST, command.method);
@@ -114,7 +110,7 @@ public class ParseRESTUserCommandTest {
         Map<String, String> facebookAuthData = new HashMap<>();
         facebookAuthData.put("token", "test");
         ParseRESTUserCommand command =
-                ParseRESTUserCommand.serviceLogInUserCommand("facebook", facebookAuthData, true);
+            ParseRESTUserCommand.serviceLogInUserCommand("facebook", facebookAuthData, true);
 
         assertEquals("users", command.httpPath);
         assertEquals(ParseHttpRequest.Method.POST, command.method);
@@ -136,7 +132,7 @@ public class ParseRESTUserCommandTest {
         JSONObject parameters = new JSONObject();
         parameters.put("key", "value");
         ParseRESTUserCommand command =
-                ParseRESTUserCommand.signUpUserCommand(parameters, "sessionToken", true);
+            ParseRESTUserCommand.signUpUserCommand(parameters, "sessionToken", true);
 
         ParseHttpRequest.Builder requestBuilder = new ParseHttpRequest.Builder();
         command.addAdditionalHeaders(requestBuilder);
@@ -157,53 +153,14 @@ public class ParseRESTUserCommandTest {
         int statusCode = 200;
 
         ParseHttpResponse response =
-                new ParseHttpResponse.Builder()
-                        .setContent(new ByteArrayInputStream(content.getBytes()))
-                        .setContentType(contentType)
-                        .setStatusCode(statusCode)
-                        .build();
+            new ParseHttpResponse.Builder()
+                .setContent(new ByteArrayInputStream(content.getBytes()))
+                .setContentType(contentType)
+                .setStatusCode(statusCode)
+                .build();
         command.onResponseAsync(response, null);
 
         assertEquals(200, command.getStatusCode());
-    }
-
-    @Test
-    public void testRequestIdHeader() throws Exception {
-        JSONArray nestedJSONArray = new JSONArray().put(true).put(1).put("test");
-        JSONObject nestedJSON =
-            new JSONObject().put("bool", false).put("int", 2).put("string", "test");
-        String sessionToken = generateRandomString(32);
-        String installationId = generateRandomString(32);
-        String masterKey = generateRandomString(32);
-        JSONObject json =
-            new JSONObject()
-                .put("json", nestedJSON)
-                .put("jsonArray", nestedJSONArray)
-                .put("bool", true)
-                .put("int", 3)
-                .put("string", "test");
-
-        String jsonString = ParseRESTCommand.toDeterministicString(json);
-
-        JSONObject jsonAgain = new JSONObject(jsonString);
-        jsonAgain.put(ParseRESTCommand.HEADER_INSTALLATION_ID, installationId);
-        jsonAgain.put(ParseRESTCommand.HEADER_SESSION_TOKEN, sessionToken);
-        jsonAgain.put(ParseRESTCommand.HEADER_MASTER_KEY, masterKey);
-        ParseRESTCommand restCommand = new ParseRESTCommand.Builder().jsonParameters(json)
-            .installationId(installationId).sessionToken(sessionToken).masterKey(masterKey)
-            .build();
-
-        ParseHttpRequest.Builder builder = new ParseHttpRequest.Builder();
-        restCommand.addAdditionalHeaders(builder);
-        assertEquals(ParseDigestUtils.md5(ParseRESTCommand.toDeterministicString(jsonAgain)), builder.build().getHeader(ParseRESTCommand.HEADER_REQUEST_ID));
-    }
-
-    private static String generateRandomString(final int sizeOfRandomString) {
-        final Random random = new Random();
-        final StringBuilder sb = new StringBuilder(sizeOfRandomString);
-        for (int i = 0; i < sizeOfRandomString; ++i)
-            sb.append(ALLOWED_CHARACTERS.charAt(random.nextInt(ALLOWED_CHARACTERS.length())));
-        return sb.toString();
     }
 
     // endregion


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues/764).

### Issue Description
Requests are duplicated on slow internet connections and during network interruptions.

Closes: [#764](https://github.com/parse-community/Parse-SDK-Android/issues/764)

### Approach
Add idempotency requestId header for client requests to enforce server side idempotency middleware on selected routes..

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
