### PR TITLE
fix: `SafeParseDelegate` ignores name parameter on `setValue`

### DIFF
--- a/ktx/src/main/java/com/parse/ktx/delegates/SafeParseDelegate.kt
+++ b/ktx/src/main/java/com/parse/ktx/delegates/SafeParseDelegate.kt
@@ -29,7 +29,7 @@ class SafeParseDelegate<T>(private val name: String?) {
     }
 
     operator fun setValue(parseObject: ParseObject, property: KProperty<*>, t: T?) {
-        parseObject.putOrRemove(property.name, t)
+        parseObject.putOrRemove(name ?: property.name, t)
     }
 }
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues?q=is%3Aissue).

### Issue Description
When a variable used the `safeAttribute(String)` function, the `setValue` (from the `SafeParseDelegate`) was not working properly when its name was different from the `name` param from the delegate because the `name` param was being ignored.

Closes: #1200

### Approach
Consider the `SafeParseDelegate`'s `name` param that is passed via constructor as it's done to `ParseDelegate`.

![image](https://github.com/parse-community/Parse-SDK-Android/assets/13617216/8f38ba64-f0a2-4626-b020-2fc6bb240d41)
