### PR TITLE
feat: Add support for uploading a `ParseFile` from a URI

### DIFF
--- a/parse/src/main/java/com/parse/ParseCountingUriHttpBody.java
+++ b/parse/src/main/java/com/parse/ParseCountingUriHttpBody.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+package com.parse;
+
+import android.net.Uri;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+class ParseCountingUriHttpBody extends ParseUriHttpBody {
+
+    private static final int DEFAULT_CHUNK_SIZE = 4096;
+    private static final int EOF = -1;
+
+    private final ProgressCallback progressCallback;
+
+    public ParseCountingUriHttpBody(Uri uri, ProgressCallback progressCallback) {
+        this(uri, null, progressCallback);
+    }
+
+    public ParseCountingUriHttpBody(
+        Uri uri, String contentType, ProgressCallback progressCallback) {
+        super(uri, contentType);
+        this.progressCallback = progressCallback;
+    }
+
+    @Override
+    public void writeTo(OutputStream output) throws IOException {
+        if (output == null) {
+            throw new IllegalArgumentException("Output stream may not be null");
+        }
+
+        final InputStream fileInput = Parse.getApplicationContext().getContentResolver().openInputStream(uri);
+        try {
+            byte[] buffer = new byte[DEFAULT_CHUNK_SIZE];
+            int n;
+            long totalLength = getContentLength();
+            long position = 0;
+            while (EOF != (n = fileInput.read(buffer))) {
+                output.write(buffer, 0, n);
+                position += n;
+
+                if (progressCallback != null) {
+                    int progress = (int) (100 * position / totalLength);
+                    progressCallback.done(progress);
+                }
+            }
+        } finally {
+            ParseIOUtils.closeQuietly(fileInput);
+        }
+    }
+}

--- a/parse/src/main/java/com/parse/ParseCountingUriHttpBody.java
+++ b/parse/src/main/java/com/parse/ParseCountingUriHttpBody.java
@@ -9,7 +9,6 @@
 package com.parse;
 
 import android.net.Uri;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -26,7 +25,7 @@ class ParseCountingUriHttpBody extends ParseUriHttpBody {
     }
 
     public ParseCountingUriHttpBody(
-        Uri uri, String contentType, ProgressCallback progressCallback) {
+            Uri uri, String contentType, ProgressCallback progressCallback) {
         super(uri, contentType);
         this.progressCallback = progressCallback;
     }
@@ -37,7 +36,8 @@ class ParseCountingUriHttpBody extends ParseUriHttpBody {
             throw new IllegalArgumentException("Output stream may not be null");
         }
 
-        final InputStream fileInput = Parse.getApplicationContext().getContentResolver().openInputStream(uri);
+        final InputStream fileInput =
+                Parse.getApplicationContext().getContentResolver().openInputStream(uri);
         try {
             byte[] buffer = new byte[DEFAULT_CHUNK_SIZE];
             int n;

--- a/parse/src/main/java/com/parse/ParseFile.java
+++ b/parse/src/main/java/com/parse/ParseFile.java
@@ -8,6 +8,7 @@
  */
 package com.parse;
 
+import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 import com.parse.boltsinternal.Continuation;
@@ -64,6 +65,7 @@ public class ParseFile implements Parcelable {
      */
     /* package for tests */ byte[] data;
     /* package for tests */ File file;
+    /* package for tests */ Uri uri;
     private State state;
 
     /**
@@ -100,6 +102,21 @@ public class ParseFile implements Parcelable {
     public ParseFile(String name, byte[] data, String contentType) {
         this(new State.Builder().name(name).mimeType(contentType).build());
         this.data = data;
+    }
+
+    /**
+     * Creates a new file from a content uri, file name, and content type. Content type will be used
+     * instead of auto-detection by file extension.
+     *
+     * @param name The file's name, ideally with extension. The file name must begin with an
+     *     alphanumeric character, and consist of alphanumeric characters, periods, spaces,
+     *     underscores, or dashes.
+     * @param uri The file uri.
+     * @param contentType The file's content type.
+     */
+    public ParseFile(String name, Uri uri, String contentType) {
+        this(new State.Builder().name(name).mimeType(contentType).build());
+        this.uri = uri;
     }
 
     /**
@@ -263,28 +280,38 @@ public class ParseFile implements Parcelable {
                         return Task.cancelled();
                     }
 
-                    Task<State> saveTask;
-                    if (data != null) {
-                        saveTask =
-                                getFileController()
-                                        .saveAsync(
-                                                state,
-                                                data,
-                                                sessionToken,
-                                                progressCallbackOnMainThread(
-                                                        uploadProgressCallback),
-                                                cancellationToken);
-                    } else {
-                        saveTask =
-                                getFileController()
-                                        .saveAsync(
-                                                state,
-                                                file,
-                                                sessionToken,
-                                                progressCallbackOnMainThread(
-                                                        uploadProgressCallback),
-                                                cancellationToken);
-                    }
+                Task<State> saveTask;
+                if (data != null) {
+                    saveTask =
+                        getFileController()
+                            .saveAsync(
+                                state,
+                                data,
+                                sessionToken,
+                                progressCallbackOnMainThread(
+                                    uploadProgressCallback),
+                                cancellationToken);
+                } else if (uri != null) {
+                    saveTask =
+                        getFileController()
+                            .saveAsync(
+                                state,
+                                uri,
+                                sessionToken,
+                                progressCallbackOnMainThread(
+                                    uploadProgressCallback),
+                                cancellationToken);
+                } else {
+                    saveTask =
+                        getFileController()
+                            .saveAsync(
+                                state,
+                                file,
+                                sessionToken,
+                                progressCallbackOnMainThread(
+                                    uploadProgressCallback),
+                                cancellationToken);
+                }
 
                     return saveTask.onSuccessTask(
                             task1 -> {

--- a/parse/src/main/java/com/parse/ParseFile.java
+++ b/parse/src/main/java/com/parse/ParseFile.java
@@ -280,38 +280,38 @@ public class ParseFile implements Parcelable {
                         return Task.cancelled();
                     }
 
-                Task<State> saveTask;
-                if (data != null) {
-                    saveTask =
-                        getFileController()
-                            .saveAsync(
-                                state,
-                                data,
-                                sessionToken,
-                                progressCallbackOnMainThread(
-                                    uploadProgressCallback),
-                                cancellationToken);
-                } else if (uri != null) {
-                    saveTask =
-                        getFileController()
-                            .saveAsync(
-                                state,
-                                uri,
-                                sessionToken,
-                                progressCallbackOnMainThread(
-                                    uploadProgressCallback),
-                                cancellationToken);
-                } else {
-                    saveTask =
-                        getFileController()
-                            .saveAsync(
-                                state,
-                                file,
-                                sessionToken,
-                                progressCallbackOnMainThread(
-                                    uploadProgressCallback),
-                                cancellationToken);
-                }
+                    Task<State> saveTask;
+                    if (data != null) {
+                        saveTask =
+                                getFileController()
+                                        .saveAsync(
+                                                state,
+                                                data,
+                                                sessionToken,
+                                                progressCallbackOnMainThread(
+                                                        uploadProgressCallback),
+                                                cancellationToken);
+                    } else if (uri != null) {
+                        saveTask =
+                                getFileController()
+                                        .saveAsync(
+                                                state,
+                                                uri,
+                                                sessionToken,
+                                                progressCallbackOnMainThread(
+                                                        uploadProgressCallback),
+                                                cancellationToken);
+                    } else {
+                        saveTask =
+                                getFileController()
+                                        .saveAsync(
+                                                state,
+                                                file,
+                                                sessionToken,
+                                                progressCallbackOnMainThread(
+                                                        uploadProgressCallback),
+                                                cancellationToken);
+                    }
 
                     return saveTask.onSuccessTask(
                             task1 -> {

--- a/parse/src/main/java/com/parse/ParseFileController.java
+++ b/parse/src/main/java/com/parse/ParseFileController.java
@@ -8,6 +8,8 @@
  */
 package com.parse;
 
+import android.net.Uri;
+
 import com.parse.boltsinternal.Task;
 import com.parse.http.ParseHttpRequest;
 import java.io.File;
@@ -161,6 +163,49 @@ class ParseFileController {
                             return newState;
                         },
                         ParseExecutors.io());
+    }
+
+    public Task<ParseFile.State> saveAsync(
+        final ParseFile.State state,
+        final Uri uri,
+        String sessionToken,
+        ProgressCallback uploadProgressCallback,
+        Task<Void> cancellationToken) {
+        if (state.url() != null) { // !isDirty
+            return Task.forResult(state);
+        }
+        if (cancellationToken != null && cancellationToken.isCancelled()) {
+            return Task.cancelled();
+        }
+
+        final ParseRESTCommand command =
+            new ParseRESTFileCommand.Builder()
+                .fileName(state.name())
+                .uri(uri)
+                .contentType(state.mimeType())
+                .sessionToken(sessionToken)
+                .build();
+
+        return command.executeAsync(restClient, uploadProgressCallback, null, cancellationToken)
+            .onSuccess(
+                task -> {
+                    JSONObject result = task.getResult();
+                    ParseFile.State newState =
+                        new ParseFile.State.Builder(state)
+                            .name(result.getString("name"))
+                            .url(result.getString("url"))
+                            .build();
+
+                    // Write data to cache
+                    try {
+                        ParseFileUtils.writeUriToFile(getCacheFile(newState), uri);
+                    } catch (IOException e) {
+                        // do nothing
+                    }
+
+                    return newState;
+                },
+                ParseExecutors.io());
     }
 
     public Task<File> fetchAsync(

--- a/parse/src/main/java/com/parse/ParseFileController.java
+++ b/parse/src/main/java/com/parse/ParseFileController.java
@@ -9,7 +9,6 @@
 package com.parse;
 
 import android.net.Uri;
-
 import com.parse.boltsinternal.Task;
 import com.parse.http.ParseHttpRequest;
 import java.io.File;
@@ -166,11 +165,11 @@ class ParseFileController {
     }
 
     public Task<ParseFile.State> saveAsync(
-        final ParseFile.State state,
-        final Uri uri,
-        String sessionToken,
-        ProgressCallback uploadProgressCallback,
-        Task<Void> cancellationToken) {
+            final ParseFile.State state,
+            final Uri uri,
+            String sessionToken,
+            ProgressCallback uploadProgressCallback,
+            Task<Void> cancellationToken) {
         if (state.url() != null) { // !isDirty
             return Task.forResult(state);
         }
@@ -179,33 +178,33 @@ class ParseFileController {
         }
 
         final ParseRESTCommand command =
-            new ParseRESTFileCommand.Builder()
-                .fileName(state.name())
-                .uri(uri)
-                .contentType(state.mimeType())
-                .sessionToken(sessionToken)
-                .build();
+                new ParseRESTFileCommand.Builder()
+                        .fileName(state.name())
+                        .uri(uri)
+                        .contentType(state.mimeType())
+                        .sessionToken(sessionToken)
+                        .build();
 
         return command.executeAsync(restClient, uploadProgressCallback, null, cancellationToken)
-            .onSuccess(
-                task -> {
-                    JSONObject result = task.getResult();
-                    ParseFile.State newState =
-                        new ParseFile.State.Builder(state)
-                            .name(result.getString("name"))
-                            .url(result.getString("url"))
-                            .build();
+                .onSuccess(
+                        task -> {
+                            JSONObject result = task.getResult();
+                            ParseFile.State newState =
+                                    new ParseFile.State.Builder(state)
+                                            .name(result.getString("name"))
+                                            .url(result.getString("url"))
+                                            .build();
 
-                    // Write data to cache
-                    try {
-                        ParseFileUtils.writeUriToFile(getCacheFile(newState), uri);
-                    } catch (IOException e) {
-                        // do nothing
-                    }
+                            // Write data to cache
+                            try {
+                                ParseFileUtils.writeUriToFile(getCacheFile(newState), uri);
+                            } catch (IOException e) {
+                                // do nothing
+                            }
 
-                    return newState;
-                },
-                ParseExecutors.io());
+                            return newState;
+                        },
+                        ParseExecutors.io());
     }
 
     public Task<File> fetchAsync(

--- a/parse/src/main/java/com/parse/ParseFileUtils.java
+++ b/parse/src/main/java/com/parse/ParseFileUtils.java
@@ -16,7 +16,13 @@
  */
 package com.parse;
 
+import android.net.Uri;
+
 import androidx.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -27,8 +33,6 @@ import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.util.List;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /** General file manipulation utilities. */
 public class ParseFileUtils {
@@ -112,6 +116,30 @@ public class ParseFileUtils {
             out.write(data);
         } finally {
             ParseIOUtils.closeQuietly(out);
+        }
+    }
+
+    /**
+     * Writes a content uri to a file creating the file if it does not exist.
+     *
+     * <p>NOTE: As from v1.3, the parent directories of the file will be created if they do not
+     * exist.
+     *
+     * @param file the file to write to
+     * @param uri  the content uri with data to write to the file
+     * @throws IOException in case of an I/O error
+     * @since Commons IO 1.1
+     */
+    public static void writeUriToFile(File file, Uri uri) throws IOException {
+        OutputStream out = null;
+        InputStream in = null;
+        try {
+            in = Parse.getApplicationContext().getContentResolver().openInputStream(uri);
+            out = openOutputStream(file);
+            ParseIOUtils.copyLarge(in, out);
+        } finally {
+            ParseIOUtils.closeQuietly(out);
+            ParseIOUtils.closeQuietly(in);
         }
     }
 

--- a/parse/src/main/java/com/parse/ParseFileUtils.java
+++ b/parse/src/main/java/com/parse/ParseFileUtils.java
@@ -17,12 +17,7 @@
 package com.parse;
 
 import android.net.Uri;
-
 import androidx.annotation.NonNull;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -33,6 +28,8 @@ import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.util.List;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /** General file manipulation utilities. */
 public class ParseFileUtils {
@@ -126,7 +123,7 @@ public class ParseFileUtils {
      * exist.
      *
      * @param file the file to write to
-     * @param uri  the content uri with data to write to the file
+     * @param uri the content uri with data to write to the file
      * @throws IOException in case of an I/O error
      * @since Commons IO 1.1
      */

--- a/parse/src/main/java/com/parse/ParseRESTFileCommand.java
+++ b/parse/src/main/java/com/parse/ParseRESTFileCommand.java
@@ -9,7 +9,6 @@
 package com.parse;
 
 import android.net.Uri;
-
 import com.parse.http.ParseHttpBody;
 import com.parse.http.ParseHttpRequest;
 import java.io.File;

--- a/parse/src/main/java/com/parse/ParseUriHttpBody.java
+++ b/parse/src/main/java/com/parse/ParseUriHttpBody.java
@@ -15,9 +15,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import android.provider.OpenableColumns;
-
 import com.parse.http.ParseHttpBody;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -38,7 +36,10 @@ class ParseUriHttpBody extends ParseHttpBody {
     private static long getUriLength(Uri uri) {
         long length = -1;
 
-        try (Cursor cursor = getApplicationContext().getContentResolver().query(uri, null, null, null, null, null)) {
+        try (Cursor cursor =
+                getApplicationContext()
+                        .getContentResolver()
+                        .query(uri, null, null, null, null, null)) {
             if (cursor != null && cursor.moveToFirst()) {
                 int sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
                 if (!cursor.isNull(sizeIndex)) {
@@ -48,7 +49,8 @@ class ParseUriHttpBody extends ParseHttpBody {
         }
         if (length == -1) {
             try {
-                ParcelFileDescriptor parcelFileDescriptor = getApplicationContext().getContentResolver().openFileDescriptor(uri, "r");
+                ParcelFileDescriptor parcelFileDescriptor =
+                        getApplicationContext().getContentResolver().openFileDescriptor(uri, "r");
                 if (parcelFileDescriptor != null) {
                     length = parcelFileDescriptor.getStatSize();
                     parcelFileDescriptor.close();
@@ -58,7 +60,10 @@ class ParseUriHttpBody extends ParseHttpBody {
         }
         if (length == -1) {
             try {
-                AssetFileDescriptor assetFileDescriptor = getApplicationContext().getContentResolver().openAssetFileDescriptor(uri, "r");
+                AssetFileDescriptor assetFileDescriptor =
+                        getApplicationContext()
+                                .getContentResolver()
+                                .openAssetFileDescriptor(uri, "r");
                 if (assetFileDescriptor != null) {
                     length = assetFileDescriptor.getLength();
                     assetFileDescriptor.close();
@@ -80,7 +85,8 @@ class ParseUriHttpBody extends ParseHttpBody {
             throw new IllegalArgumentException("Output stream can not be null");
         }
 
-        final InputStream fileInput = getApplicationContext().getContentResolver().openInputStream(uri);
+        final InputStream fileInput =
+                getApplicationContext().getContentResolver().openInputStream(uri);
         try {
             ParseIOUtils.copy(fileInput, out);
         } finally {

--- a/parse/src/main/java/com/parse/ParseUriHttpBody.java
+++ b/parse/src/main/java/com/parse/ParseUriHttpBody.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+package com.parse;
+
+import static com.parse.Parse.getApplicationContext;
+
+import android.content.res.AssetFileDescriptor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+
+import com.parse.http.ParseHttpBody;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+class ParseUriHttpBody extends ParseHttpBody {
+
+    /* package */ final Uri uri;
+
+    public ParseUriHttpBody(Uri uri) {
+        this(uri, null);
+    }
+
+    public ParseUriHttpBody(Uri uri, String contentType) {
+        super(contentType, getUriLength(uri));
+        this.uri = uri;
+    }
+
+    private static long getUriLength(Uri uri) {
+        long length = -1;
+        try {
+            ParcelFileDescriptor parcelFileDescriptor = getApplicationContext().getContentResolver().openFileDescriptor(uri, "r");
+            if (parcelFileDescriptor != null) {
+                length = parcelFileDescriptor.getStatSize();
+                parcelFileDescriptor.close();
+            }
+        } catch (IOException ignored) {
+        }
+        if (length == -1) {
+            try {
+                AssetFileDescriptor assetFileDescriptor = getApplicationContext().getContentResolver().openAssetFileDescriptor(uri, "r");
+                if (assetFileDescriptor != null) {
+                    length = assetFileDescriptor.getLength();
+                    assetFileDescriptor.close();
+                }
+            } catch (IOException ignored) {
+            }
+        }
+        return length;
+    }
+
+    @Override
+    public InputStream getContent() throws IOException {
+        return getApplicationContext().getContentResolver().openInputStream(uri);
+    }
+
+    @Override
+    public void writeTo(OutputStream out) throws IOException {
+        if (out == null) {
+            throw new IllegalArgumentException("Output stream can not be null");
+        }
+
+        final InputStream fileInput = getApplicationContext().getContentResolver().openInputStream(uri);
+        try {
+            ParseIOUtils.copy(fileInput, out);
+        } finally {
+            ParseIOUtils.closeQuietly(fileInput);
+        }
+    }
+}

--- a/parse/src/test/java/com/parse/ParseCountingUriHttpBodyTest.java
+++ b/parse/src/test/java/com/parse/ParseCountingUriHttpBodyTest.java
@@ -13,11 +13,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import android.net.Uri;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileWriter;
@@ -25,6 +20,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class ParseCountingUriHttpBodyTest {
 

--- a/parse/src/test/java/com/parse/ParseCountingUriHttpBodyTest.java
+++ b/parse/src/test/java/com/parse/ParseCountingUriHttpBodyTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+package com.parse;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.net.Uri;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+public class ParseCountingUriHttpBodyTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static String getData() {
+        char[] chars = new char[64 << 14]; // 1MB
+        Arrays.fill(chars, '1');
+        return new String(chars);
+    }
+
+    private static Uri makeTestUri(File root) throws IOException {
+        File file = new File(root, "test");
+        FileWriter writer = new FileWriter(file);
+        writer.write(getData());
+        writer.close();
+        return Uri.fromFile(file);
+    }
+
+    @Test
+    public void testWriteTo() throws Exception {
+        final Semaphore didReportIntermediateProgress = new Semaphore(0);
+        final Semaphore finish = new Semaphore(0);
+
+        ParseCountingUriHttpBody body =
+                new ParseCountingUriHttpBody(
+                        makeTestUri(temporaryFolder.getRoot()),
+                        new ProgressCallback() {
+                            Integer maxProgressSoFar = 0;
+
+                            @Override
+                            public void done(Integer percentDone) {
+                                if (percentDone > maxProgressSoFar) {
+                                    maxProgressSoFar = percentDone;
+                                    assertTrue(percentDone >= 0 && percentDone <= 100);
+
+                                    if (percentDone < 100 && percentDone > 0) {
+                                        didReportIntermediateProgress.release();
+                                    } else if (percentDone == 100) {
+                                        finish.release();
+                                    } else if (percentDone == 0) {
+                                        // do nothing
+                                    } else {
+                                        fail("percentDone should be within 0 - 100");
+                                    }
+                                }
+                            }
+                        });
+
+        // Check content
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        body.writeTo(output);
+        assertArrayEquals(getData().getBytes(), output.toByteArray());
+        // Check progress callback
+        assertTrue(didReportIntermediateProgress.tryAcquire(5, TimeUnit.SECONDS));
+        assertTrue(finish.tryAcquire(5, TimeUnit.SECONDS));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWriteToWithNullOutput() throws Exception {
+        ParseCountingUriHttpBody body =
+                new ParseCountingUriHttpBody(makeTestUri(temporaryFolder.getRoot()), null);
+        body.writeTo(null);
+    }
+}

--- a/parse/src/test/java/com/parse/ParseFileControllerTest.java
+++ b/parse/src/test/java/com/parse/ParseFileControllerTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.net.Uri;
-
 import com.parse.boltsinternal.Task;
 import com.parse.http.ParseHttpRequest;
 import com.parse.http.ParseHttpResponse;

--- a/parse/src/test/java/com/parse/ParseUriHttpBodyTest.java
+++ b/parse/src/test/java/com/parse/ParseUriHttpBodyTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2015-present, Parse, LLC.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+package com.parse;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import android.net.Uri;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+
+public class ParseUriHttpBodyTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testInitializeWithUri() throws IOException {
+        byte[] content = {1, 1, 1, 1, 1};
+        String contentType = "application/json";
+        File file = temporaryFolder.newFile("name");
+        ParseFileUtils.writeByteArrayToFile(file, content);
+        Uri uri = Uri.fromFile(file);
+        ParseUriHttpBody body = new ParseUriHttpBody(uri, contentType);
+        assertArrayEquals(content, ParseIOUtils.toByteArray(body.getContent()));
+        assertEquals(contentType, body.getContentType());
+        assertEquals(5, body.getContentLength());
+    }
+
+    @Test
+    public void testWriteTo() throws IOException {
+        String content = "content";
+        String contentType = "application/json";
+        File file = temporaryFolder.newFile("name");
+        ParseFileUtils.writeStringToFile(file, content, "UTF-8");
+        Uri uri = Uri.fromFile(file);
+        ParseUriHttpBody body = new ParseUriHttpBody(uri, contentType);
+
+        // Check content
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        body.writeTo(output);
+        String contentAgain = output.toString();
+        assertEquals(content, contentAgain);
+
+        // No need to check whether content input stream is closed since it is a
+        // ByteArrayInputStream
+    }
+}

--- a/parse/src/test/java/com/parse/ParseUriHttpBodyTest.java
+++ b/parse/src/test/java/com/parse/ParseUriHttpBodyTest.java
@@ -12,18 +12,15 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import android.net.Uri;
-
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-
 public class ParseUriHttpBodyTest {
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void testInitializeWithUri() throws IOException {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [X] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [X] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Adds support for uploading a `ParseFile` from a `Uri`.

Closes: #1206 

### Approach
<!-- Add a description of the approach in this PR. -->
Followed the code from how it works using a File and byte[].

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
