### PR TITLE
fix: Tests failing due to disabling JUnitPlatform which is causing 0% coverage reports

### DIFF
--- a/parse/build.gradle
+++ b/parse/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     api "com.squareup.okhttp3:okhttp:$okhttpVersion"
     api project(':bolts-tasks')
 
+    testRuntimeOnly('org.junit.vintage:junit-vintage-engine:5.10.2')
     testImplementation "org.junit.jupiter:junit-jupiter:$rootProject.ext.jupiterVersion"
     testImplementation "org.skyscreamer:jsonassert:1.5.0"
     testImplementation "junit:junit:$rootProject.ext.junitVersion"


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues/1217).

### Issue Description
Some tests are failing after disabling JUnitPlatform.

Closes: [#1217](https://github.com/parse-community/Parse-SDK-Android/issues/1217).

### Approach
Fix failing tests without enabling JUnitPlatform.

### TODOs before merging

- [x] Fix ParseCountingUriHttpBodyTest.testWriteToWithNullOutput
- [x] Fix ParseCountingUriHttpBodyTest.testWriteTo
- [x] Fix ParseFileControllerTest.testSaveAsyncSuccessWithUri
- [x] Fix ParseFileTest.testSaveAsyncSuccessWithUri
- [x] Fix ParseUriHttpBodyTest.testInitializeWithUri
- [x] Fix ParseUriHttpBodyTest.testWriteTo
- [ ] Fix ParseCorePluginsTest.testQueryControllerDefaultImpl
- [ ] Fix ParseDecoderTest.testCompleteness
- [ ] Fix ParseDecoderTest.testCompletenessOfIncludedParseObject