### PR TITLE
fix: R8 compiler logs warnings due to missing ProGuard rules for OkHttp

### DIFF
--- a/parse/build.gradle
+++ b/parse/build.gradle
@@ -42,7 +42,7 @@ android {
 }
 
 ext {
-    okhttpVersion = "4.10.0"
+    okhttpVersion = "4.12.0"
 }
 
 dependencies {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Server!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/parse-community/Parse-SDK-Android/blob/master/SECURITY.md).
- [x] I am creating this PR in reference to an [issue](https://github.com/parse-community/Parse-SDK-Android/issues/1221).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: https://github.com/parse-community/Parse-SDK-Android/issues/1221

### Approach
<!-- Add a description of the approach in this PR. -->
Update OkHttp dependency from 4.10.0 to 4.12.0

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] No tests required
- [x] No documentation changes required
