### PR TITLE
ci: Replace third-party GitHub Actions with trusted alternatives

### DIFF
--- a/.github/workflows/release-automated.yml
+++ b/.github/workflows/release-automated.yml
@@ -5,6 +5,13 @@ on:
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -16,15 +23,15 @@ jobs:
           distribution: 'adopt'
       - name: Generate Javadoc
         run: javadoc @.javadoc || true
-      - name: Deploy GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          clean: true
-          folder: doc
-          target-folder: api
-          dry-run: false
+          path: doc
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
   release:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release-manual-docs.yml
+++ b/.github/workflows/release-manual-docs.yml
@@ -7,6 +7,13 @@ on: workflow_dispatch
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,12 +25,12 @@ jobs:
           distribution: 'adopt'
       - name: Generate Javadoc
         run: javadoc @.javadoc || true
-      - name: Deploy GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          clean: true
-          folder: doc
-          target-folder: api
-          dry-run: false
+          path: doc
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
Replace untrusted third-party GitHub Actions with official alternatives to reduce supply chain attack surface.

## Changes
- Replace `JamesIves/github-pages-deploy-action` with official `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages` pipeline

## Note
The repository Pages source setting must be changed to "GitHub Actions" in Settings > Pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment infrastructure to use official GitHub Pages actions for improved reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->